### PR TITLE
Externalize build properties.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id("org.jetbrains.intellij") version "0.3.7"
 
@@ -13,8 +29,9 @@ allprojects {
     apply(plugin = "kotlin")
 
     intellij {
-        type = "IC"
-        version = "2018.2"
+        type = project.properties["ideaEdition"].toString()
+        version = project.properties["ideaVersion"].toString()
+        intellijRepo = project.properties["intellijRepoUrl"].toString()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ideaEdition = IC
+ideaVersion = 2018.2
+intellijRepoUrl = https://www.jetbrains.com/intellij-repository

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,17 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 include 'skaffold'


### PR DESCRIPTION
Fixes #15.

Also uses company copyright headers for build files, previously missed.