### PR TITLE
Add ktlint Kotlin linter via Spotless plugin

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -4,6 +4,8 @@
     <bytecodeTargetLevel>
       <module name="google-container-tools-intellij_main" target="1.8" />
       <module name="google-container-tools-intellij_test" target="1.8" />
+      <module name="skaffold_main" target="1.8" />
+      <module name="skaffold_test" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.jetbrains.intellij") version "0.3.7"
+    id("com.diffplug.gradle.spotless") version "3.14.0"
 
     kotlin("jvm") version "1.2.61"
 }
@@ -11,10 +12,22 @@ allprojects {
 
     apply(plugin = "org.jetbrains.intellij")
     apply(plugin = "kotlin")
+    apply(plugin = "com.diffplug.gradle.spotless")
 
     intellij {
         type = "IC"
         version = "2018.2"
+    }
+
+    spotless {
+        kotlin {
+            ktlint()
+        }
+
+        kotlinGradle {
+            target("**/*.kts", "**/src/**/*.kt")
+            ktlint()
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,12 @@ allprojects {
 
     spotless {
         kotlin {
+            target("**/src/**/*.kt")
             ktlint()
         }
 
         kotlinGradle {
-            target("**/*.kts", "**/src/**/*.kt")
+            target("**/*.gradle.kts")
             ktlint()
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,8 @@ allprojects {
     spotless {
         kotlin {
             target("**/src/**/*.kt")
-            ktlint()
+            // Set ktlint to follow the Android Style Guide for source files
+            ktlint().userData(mapOf("android" to "true"))
         }
 
         kotlinGradle {

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldUiResources.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldUiResources.kt
@@ -28,6 +28,9 @@ private const val BUNDLE_NAME = "messages.SkaffoldBundle"
 /**
  * Returns message by provided key from Skaffold message bundle with optional parameters.
  */
-internal fun message(@PropertyKey(resourceBundle = BUNDLE_NAME) key: String, vararg params: String): String {
+internal fun message(
+    @PropertyKey(resourceBundle = BUNDLE_NAME) key: String,
+    vararg params: String
+): String {
     return CommonBundle.message(ResourceBundle.getBundle(BUNDLE_NAME), key, params)
 }


### PR DESCRIPTION
fixes #16 

Spotless plugin (used in cloud tools for intellij also) has built in support for ktlint.

There are a few peculiarities that we can iron out as we go along:

- the IJ formatter doesn't seem to enforce the line length rule (even though the linter will fail since 100 char limit is part of the Android Studio style guide)
- The current settings can lead to some strange formatting (see the changes to `SkaffoldUiResources` in this PR). As far as I can tell this is correct Kotlin styling 
- ktlint has some basic auto-formatting limitations: it cannot (yet?) auto-format indentation problems, convert wildcard imports etc.. The IntelliJ formatter / import optimizer can fix these though.