### PR TITLE
Sets up initial test module structure, container test rule and initial Skaffold file tests.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,13 @@ allprojects {
         intellijRepo = project.properties["intellijRepoUrl"].toString()
     }
 
+    dependencies {
+        testCompile(project(":common-test-lib"))
+        testCompile("com.google.truth:truth:+") {
+            exclude(group = "com.google.guava", module = "guava")
+        }
+    }
+
     spotless {
         kotlin {
             target("**/src/**/*.kt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,6 @@ allprojects {
     }
 
     dependencies {
-        testCompile(project(":common-test-lib"))
         testCompile("com.google.truth:truth:+") {
             exclude(group = "com.google.guava", module = "guava")
         }

--- a/common-test-lib/build.gradle.kts
+++ b/common-test-lib/build.gradle.kts
@@ -13,6 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-dependencies {
-}

--- a/common-test-lib/build.gradle.kts
+++ b/common-test-lib/build.gradle.kts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-include 'skaffold'
-include 'common-test-lib'
+dependencies {
+}

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -23,7 +23,6 @@ import com.intellij.util.ThrowableRunnable
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import kotlin.properties.Delegates
 
 /**
  * A custom [TestRule] for Container Tools unit tests.
@@ -34,7 +33,7 @@ import kotlin.properties.Delegates
  *    this text fixture is "light", i.e. instance of [LightIdeaTestFixture].
  */
 class ContainerToolsRule : TestRule {
-    var ideaProjectTestFixture: IdeaProjectTestFixture by Delegates.notNull()
+    lateinit var ideaProjectTestFixture: IdeaProjectTestFixture
 
     override fun apply(baseStatement: Statement, description: Description): Statement {
         return object : Statement() {

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -25,8 +25,16 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import kotlin.properties.Delegates
 
+/**
+ * A custom [TestRule] for Container Tools unit tests.
+ *
+ * This rule adds the following functionality:
+ *
+ *  * Creates an [IdeaProjectTestFixture] and makes it available for tests via property. By default
+ *    this text fixture is "light", i.e. instance of [LightIdeaTestFixture].
+ */
 class ContainerToolsRule : TestRule {
-    var lightTestFixture: IdeaProjectTestFixture by Delegates.notNull()
+    var ideaProjectTestFixture: IdeaProjectTestFixture by Delegates.notNull()
 
     override fun apply(baseStatement: Statement, description: Description): Statement {
         return object : Statement() {
@@ -42,12 +50,12 @@ class ContainerToolsRule : TestRule {
     }
 
     private fun setUpRule() {
-        lightTestFixture =
+        ideaProjectTestFixture =
             IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture
-        EdtTestUtil.runInEdtAndWait(ThrowableRunnable { lightTestFixture.setUp() })
+        EdtTestUtil.runInEdtAndWait(ThrowableRunnable { ideaProjectTestFixture.setUp() })
     }
 
     private fun tearDownRule() {
-        EdtTestUtil.runInEdtAndWait(ThrowableRunnable { lightTestFixture.tearDown() })
+        EdtTestUtil.runInEdtAndWait(ThrowableRunnable { ideaProjectTestFixture.tearDown() })
     }
 }

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -35,8 +35,8 @@ import org.junit.runners.model.Statement
 class ContainerToolsRule : TestRule {
     lateinit var ideaProjectTestFixture: IdeaProjectTestFixture
 
-    override fun apply(baseStatement: Statement, description: Description): Statement {
-        return object : Statement() {
+    override fun apply(baseStatement: Statement, description: Description): Statement =
+        object : Statement() {
             override fun evaluate() {
                 try {
                     setUpRule()
@@ -46,8 +46,7 @@ class ContainerToolsRule : TestRule {
                 }
             }
         }
-    }
-
+    
     private fun setUpRule() {
         ideaProjectTestFixture =
             IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -27,7 +27,7 @@ import org.junit.runners.model.Statement
 import kotlin.properties.Delegates
 
 class ContainerToolsRule : TestRule {
-    private var lightTestFixture: IdeaProjectTestFixture by Delegates.notNull()
+    var lightTestFixture: IdeaProjectTestFixture by Delegates.notNull()
 
     override fun apply(baseStatement: Statement, description: Description): Statement {
         return object : Statement() {

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -46,7 +46,7 @@ class ContainerToolsRule : TestRule {
                 }
             }
         }
-    
+
     private fun setUpRule() {
         ideaProjectTestFixture =
             IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -16,7 +16,6 @@
 
 package com.google.container.tools.test
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.testFramework.EdtTestUtil
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
@@ -45,14 +44,10 @@ class ContainerToolsRule : TestRule {
     private fun setUpRule() {
         lightTestFixture =
             IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture
-        EdtTestUtil.runInEdtAndWait(object : ThrowableRunnable<Throwable> {
-            override fun run() {
-                lightTestFixture.setUp()
-            }
-        })
+        EdtTestUtil.runInEdtAndWait(ThrowableRunnable { lightTestFixture.setUp() })
     }
 
     private fun tearDownRule() {
-        ApplicationManager.getApplication().invokeAndWait { lightTestFixture.tearDown() }
+        EdtTestUtil.runInEdtAndWait(ThrowableRunnable { lightTestFixture.tearDown() })
     }
 }

--- a/common-test-lib/src/test/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/test/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.test
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.EdtTestUtil
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.util.ThrowableRunnable
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import kotlin.properties.Delegates
+
+class ContainerToolsRule : TestRule {
+    private var lightTestFixture: IdeaProjectTestFixture by Delegates.notNull()
+
+    override fun apply(baseStatement: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                try {
+                    setUpRule()
+                    baseStatement.evaluate()
+                } finally {
+                    tearDownRule()
+                }
+            }
+        }
+    }
+
+    private fun setUpRule() {
+        lightTestFixture =
+            IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture
+        EdtTestUtil.runInEdtAndWait(object : ThrowableRunnable<Throwable> {
+            override fun run() {
+                lightTestFixture.setUp()
+            }
+        })
+    }
+
+    private fun tearDownRule() {
+        ApplicationManager.getApplication().invokeAndWait { lightTestFixture.tearDown() }
+    }
+}

--- a/skaffold/build.gradle.kts
+++ b/skaffold/build.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+    compile(project(":common-test-lib"))
+}

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFiles.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFiles.kt
@@ -35,7 +35,7 @@ private val SKAFFOLD_API_HEADER_PATTERN: Pattern by lazy {
 /**
  * Checks if a given file is a valid Skaffold configuration file based on type and API version.
  */
-internal fun isSkaffoldFile(file: VirtualFile): Boolean {
+fun isSkaffoldFile(file: VirtualFile): Boolean {
     with(file) {
         if (!isDirectory && fileType is YAMLFileType && isValid) {
             val inputStream: InputStream = ByteArrayInputStream(contentsToByteArray())

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -38,7 +38,13 @@ class SkaffoldFilesTest {
     @Test
     fun `extra spaces and tabs in header skaffold file is accepted`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
-        skaffoldFile.setText("  apiVersion:    skaffold/v1alpha3")
+        skaffoldFile.setText(
+            """ apiVersion:    skaffold/v1alpha3
+                  kind: Config
+                  build:
+
+            """
+        )
 
         assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
     }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -36,7 +36,7 @@ class SkaffoldFilesTest {
     }
 
     @Test
-    fun `frivolously formatted skaffold file is accepted`() {
+    fun `extra spaces and tabs in header skaffold file is accepted`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         skaffoldFile.setText("  apiVersion:    skaffold/v1alpha3")
 

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.mock.MockVirtualFile
+import org.junit.Test
+
+class SkaffoldFilesTest {
+    @Test
+    fun `empty project return empty list`() {
+    }
+
+    @Test
+    fun `valid skaffold file is recognized`() {
+        val skaffoldFile: MockVirtualFile = MockVirtualFile.file("skaffold.yaml")
+        skaffoldFile.setText("apiVersion: skaffold/v1alpha2")
+
+        assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
+    }
+
+    @Test
+    fun `kubernetes file is not valid skaffold file`() {
+        val k8sFile: MockVirtualFile = MockVirtualFile.file("deploy.yaml")
+        k8sFile.setText("apiVersion: apps/v1")
+
+        assertThat(isSkaffoldFile(k8sFile)).isFalse()
+    }
+}

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -22,14 +22,23 @@ import com.intellij.mock.MockVirtualFile
 import org.junit.Rule
 import org.junit.Test
 
+/** Unit tests for Skaffold files functionality in [SkaffoldFiles.kt] */
 class SkaffoldFilesTest {
     @get:Rule
-    val containerToolsRule: ContainerToolsRule = ContainerToolsRule()
+    val containerToolsRule = ContainerToolsRule()
 
     @Test
-    fun `valid skaffold file is recognized`() {
+    fun `valid skaffold file is accepted`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         skaffoldFile.setText("apiVersion: skaffold/v1alpha2")
+
+        assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
+    }
+
+    @Test
+    fun `frivolously formatted skaffold file is accepted`() {
+        val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
+        skaffoldFile.setText("  apiVersion:    skaffold/v1alpha3")
 
         assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
     }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -17,17 +17,18 @@
 package com.google.container.tools.skaffold
 
 import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.test.ContainerToolsRule
 import com.intellij.mock.MockVirtualFile
+import org.junit.Rule
 import org.junit.Test
 
 class SkaffoldFilesTest {
-    @Test
-    fun `empty project return empty list`() {
-    }
+    @get:Rule
+    val containerToolsRule: ContainerToolsRule = ContainerToolsRule()
 
     @Test
     fun `valid skaffold file is recognized`() {
-        val skaffoldFile: MockVirtualFile = MockVirtualFile.file("skaffold.yaml")
+        val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         skaffoldFile.setText("apiVersion: skaffold/v1alpha2")
 
         assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
@@ -35,7 +36,7 @@ class SkaffoldFilesTest {
 
     @Test
     fun `kubernetes file is not valid skaffold file`() {
-        val k8sFile: MockVirtualFile = MockVirtualFile.file("deploy.yaml")
+        val k8sFile = MockVirtualFile.file("deploy.yaml")
         k8sFile.setText("apiVersion: apps/v1")
 
         assertThat(isSkaffoldFile(k8sFile)).isFalse()


### PR DESCRIPTION
Works towards #37, and #19.

Initializes unit tests rule for using IDE project and module basic test fixture, similar to [CloudToolsRule](https://github.com/GoogleCloudPlatform/google-cloud-intellij/blob/master/common-test-lib/src/main/java/com/google/cloud/tools/intellij/testing/CloudToolsRule.java).

For the start, test fixtures are always "light", i.e. giving minimal IDE infrastructure with slimmed down project and module support which should speed up the tests and be enough for majority of the unit tests.

Unit test names follow the convention most Kotlin tests follow.

Next PR will also add unit tests for project-based YAML search once I figure out proper way to add files to the mock project.

