### PR TITLE
Changed Kotlin to compile to 1.8 bytecodes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 /*
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
@@ -36,6 +38,10 @@ allprojects {
         type = project.properties["ideaEdition"].toString()
         version = project.properties["ideaVersion"].toString()
         intellijRepo = project.properties["intellijRepoUrl"].toString()
+    }
+
+    tasks.withType<KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
     }
 
     spotless {


### PR DESCRIPTION
Fixes #41.

Default target is 1.6, not compatible with some of the required features such as UI DSL.