### PR TITLE
Created initial support for Mockk, IJ test services, Skaffold files as a service to test SkaffoldComboBox.

### DIFF
--- a/.idea/dictionaries/ivanporty.xml
+++ b/.idea/dictionaries/ivanporty.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="ivanporty">
+    <words>
+      <w>skaffold</w>
+    </words>
+  </dictionary>
+</component>

--- a/.idea/dictionaries/ivanporty.xml
+++ b/.idea/dictionaries/ivanporty.xml
@@ -1,7 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="ivanporty">
-    <words>
-      <w>skaffold</w>
-    </words>
-  </dictionary>
-</component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 /*
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
@@ -15,6 +13,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("org.jetbrains.intellij") version "0.3.7"
@@ -48,6 +48,7 @@ allprojects {
         testCompile("com.google.truth:truth:+") {
             exclude(group = "com.google.guava", module = "guava")
         }
+        testCompile("io.mockk:mockk:+")
     }
 
     spotless {

--- a/common-test-lib/build.gradle.kts
+++ b/common-test-lib/build.gradle.kts
@@ -13,3 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+dependencies {
+    // required for container tools rule not in the test code.
+    compile("io.mockk:mockk:+")
+}

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -37,6 +37,8 @@ import kotlin.reflect.jvm.isAccessible
  *
  *  * Creates an [IdeaProjectTestFixture] and makes it available for tests via property. By default
  *    this text fixture is "light", i.e. instance of [LightIdeaTestFixture].
+ *  * Replaces all fields annotated with [TestService] in the
+ *    [PicoContainer][org.picocontainer.PicoContainer] with the field values.
  */
 class ContainerToolsRule(private val testInstance: Any) : TestRule {
     lateinit var ideaProjectTestFixture: IdeaProjectTestFixture

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -16,13 +16,20 @@
 
 package com.google.container.tools.test
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.testFramework.EdtTestUtil
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.util.ThrowableRunnable
+import io.mockk.MockKAnnotations
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.picocontainer.MutablePicoContainer
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.isAccessible
 
 /**
  * A custom [TestRule] for Container Tools unit tests.
@@ -32,7 +39,7 @@ import org.junit.runners.model.Statement
  *  * Creates an [IdeaProjectTestFixture] and makes it available for tests via property. By default
  *    this text fixture is "light", i.e. instance of [LightIdeaTestFixture].
  */
-class ContainerToolsRule : TestRule {
+class ContainerToolsRule(val testInstance: Any) : TestRule {
     lateinit var ideaProjectTestFixture: IdeaProjectTestFixture
 
     override fun apply(baseStatement: Statement, description: Description): Statement =
@@ -51,9 +58,40 @@ class ContainerToolsRule : TestRule {
         ideaProjectTestFixture =
             IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture
         EdtTestUtil.runInEdtAndWait(ThrowableRunnable { ideaProjectTestFixture.setUp() })
+
+        MockKAnnotations.init(testInstance, relaxUnitFun = true)
+        replaceServices()
     }
 
     private fun tearDownRule() {
         EdtTestUtil.runInEdtAndWait(ThrowableRunnable { ideaProjectTestFixture.tearDown() })
+    }
+
+    /**
+     * Replaces all services annotated with [TestService].
+     */
+    private fun replaceServices() {
+        for (member in testInstance::class.declaredMemberProperties) {
+            if (member.annotations.filter { it is TestService }.isNotEmpty()) {
+                member as KProperty1<Any?, Any?>
+                member.isAccessible = true
+                val service: Any = member.get(testInstance)!!
+                setService(member::class, service)
+            }
+        }
+    }
+
+    /**
+     * Replaces the service binding in the [MutablePicoContainer] with the given instance and
+     * returns the original service instance.
+     *
+     * @param clazz the class of the registered service
+     * @param newInstance the new instance to register
+     */
+    private fun setService(clazz: KClass<*>, newInstance: Any) {
+        val applicationContainer =
+            ApplicationManager.getApplication().picoContainer as MutablePicoContainer
+        applicationContainer.unregisterComponent(clazz.simpleName)
+        applicationContainer.registerComponentInstance(clazz.simpleName, newInstance)
     }
 }

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -87,12 +87,12 @@ class ContainerToolsRule(private val testInstance: Any) : TestRule {
      * @param newInstance the new instance to register
      */
     private fun setService(newInstance: Any) {
-        val applicationContainer =
-            ApplicationManager.getApplication().picoContainer as MutablePicoContainer
-        applicationContainer.unregisterComponent(newInstance::class.java.name)
-        applicationContainer.registerComponentInstance(
-            newInstance::class.java.name,
-            newInstance
-        )
+        with(ApplicationManager.getApplication().picoContainer as MutablePicoContainer) {
+            unregisterComponent(newInstance::class.java.name)
+            registerComponentInstance(
+                newInstance::class.java.name,
+                newInstance
+            )
+        }
     }
 }

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestService.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestService.kt
@@ -27,17 +27,17 @@ package com.google.container.tools.test
  * to substitute the real service in the [PicoContainer][org.picocontainer.PicoContainer]:
  *
  * ```
- * @Rule public final ContainerToolsRule rule = new ContainerToolsRule(this)
+ * @get:Rule val  ContainerToolsRule rule = new ContainerToolsRule(this)
  *
- * @TestService mockCloudSdkService: XxxService = mockk()
+ * @TestService @MockK mockXxxService: XxxService
  * ```
  *
  * Now this mock can be used like any other Mockk variable:
  *
  * ```
- * every { mockCloudSdkService.validateCloudSdk() } returns listOf()
+ * every { mockXxxService.getData() } returns listOf()
  * ```
  */
-@Target(AnnotationTarget.FIELD)
+@Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class TestService

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestService.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestService.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.test
+
+/**
+ * Indicates that the annotated field should replace the registered service in the application's
+ * [PicoContainer][org.picocontainer.PicoContainer].
+ *
+ *
+ * This is often used in conjunction with the [Mockk][io.mockk.mockk] annotation to replace
+ * the real service with a mock. [ContainerToolsRule] handles the set-up and tear-down involved
+ * for these services. For example, this is all that is required for a mocked `XxxService`
+ * to substitute the real service in the [PicoContainer][org.picocontainer.PicoContainer]:
+ *
+ * ```
+ * @Rule public final ContainerToolsRule rule = new ContainerToolsRule(this)
+ *
+ * @TestService mockCloudSdkService: XxxService = mockk()
+ * ```
+ *
+ * Now this mock can be used like any other Mockk variable:
+ *
+ * ```
+ * every { mockCloudSdkService.validateCloudSdk() } returns listOf()
+ * ```
+ */
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TestService

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFileService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFileService.kt
@@ -33,29 +33,29 @@ private val SKAFFOLD_API_HEADER_PATTERN: Pattern by lazy {
     Pattern.compile(SKAFFOLD_API_HEADER_REGEX)
 }
 
-/**
- * Checks if a given file is a valid Skaffold configuration file based on type and API version.
- */
-fun isSkaffoldFile(file: VirtualFile): Boolean {
-    with(file) {
-        if (!isDirectory && fileType is YAMLFileType && isValid) {
-            val inputStream: InputStream = ByteArrayInputStream(contentsToByteArray())
-            inputStream.use {
-                val scanner = Scanner(it)
-                // consider this YAML file as Skaffold when first line contains proper API version
-                return scanner.hasNextLine() &&
-                    SKAFFOLD_API_HEADER_PATTERN.matcher(scanner.nextLine()).find()
-            }
-        }
-    }
-    return false
-}
-
 /** Obtains current active implementation of [SkaffoldFileService] */
 fun getSkaffoldFileService() = ServiceManager.getService(SkaffoldFileService::class.java)!!
 
 /** IDE service for findind Skaffold files in the given IDE project. */
 class SkaffoldFileService {
+
+    /**
+     * Checks if a given file is a valid Skaffold configuration file based on type and API version.
+     */
+    fun isSkaffoldFile(file: VirtualFile): Boolean {
+        with(file) {
+            if (!isDirectory && fileType is YAMLFileType && isValid) {
+                val inputStream: InputStream = ByteArrayInputStream(contentsToByteArray())
+                inputStream.use {
+                    val scanner = Scanner(it)
+                    // consider this YAML file as Skaffold when first line contains proper API version
+                    return scanner.hasNextLine() &&
+                        SKAFFOLD_API_HEADER_PATTERN.matcher(scanner.nextLine()).find()
+                }
+            }
+        }
+        return false
+    }
 
     /**
      * Finds all Skaffold configuration YAML files in the given project.

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFileService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFileService.kt
@@ -33,11 +33,13 @@ private val SKAFFOLD_API_HEADER_PATTERN: Pattern by lazy {
     Pattern.compile(SKAFFOLD_API_HEADER_REGEX)
 }
 
-/** Obtains current active implementation of [SkaffoldFileService] */
-fun getSkaffoldFileService() = ServiceManager.getService(SkaffoldFileService::class.java)!!
-
-/** IDE service for findind Skaffold files in the given IDE project. */
+/** IDE service for finding Skaffold files in the given IDE project. */
 class SkaffoldFileService {
+    companion object {
+        /** Current active implementation of [SkaffoldFileService] */
+        val instance: SkaffoldFileService
+            get() = ServiceManager.getService(SkaffoldFileService::class.java)!!
+    }
 
     /**
      * Checks if a given file is a valid Skaffold configuration file based on type and API version.

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFiles.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldFiles.kt
@@ -16,6 +16,7 @@
 
 package com.google.container.tools.skaffold
 
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FileTypeIndex
@@ -50,13 +51,20 @@ fun isSkaffoldFile(file: VirtualFile): Boolean {
     return false
 }
 
-/**
- * Finds all Skaffold configuration YAML files in the given project.
- *
- * @param project IDE project to search Skaffold file in
- * @return List of Skaffold configuration files in the project.
- */
-fun findSkaffoldFiles(project: Project): List<VirtualFile> {
-    return FileTypeIndex.getFiles(YAMLFileType.YML, GlobalSearchScope.allScope(project))
-        .filter { isSkaffoldFile(it) }
+/** Obtains current active implementation of [SkaffoldFileService] */
+fun getSkaffoldFileService() = ServiceManager.getService(SkaffoldFileService::class.java)!!
+
+/** IDE service for findind Skaffold files in the given IDE project. */
+class SkaffoldFileService {
+
+    /**
+     * Finds all Skaffold configuration YAML files in the given project.
+     *
+     * @param project IDE project to search Skaffold file in
+     * @return List of Skaffold configuration files in the project.
+     */
+    fun findSkaffoldFiles(project: Project): List<VirtualFile> {
+        return FileTypeIndex.getFiles(YAMLFileType.YML, GlobalSearchScope.allScope(project))
+            .filter { isSkaffoldFile(it) }
+    }
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -16,7 +16,7 @@
 
 package com.google.container.tools.skaffold.run
 
-import com.google.container.tools.skaffold.isSkaffoldFile
+import com.google.container.tools.skaffold.getSkaffoldFileService
 import com.google.container.tools.skaffold.message
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.options.ConfigurationException
@@ -47,7 +47,7 @@ open class BaseSkaffoldSettingsEditor : SettingsEditor<RunConfiguration>() {
             skaffoldFilesComboBox.getItemAt(skaffoldFilesComboBox.selectedIndex)
                 ?: throw ConfigurationException(message("skaffold.no.file.selected.error"))
 
-        if (!isSkaffoldFile(selectedSkaffoldFile)) {
+        if (!getSkaffoldFileService().isSkaffoldFile(selectedSkaffoldFile)) {
             throw ConfigurationException(message("skaffold.invalid.file.error"))
         }
     }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -16,7 +16,7 @@
 
 package com.google.container.tools.skaffold.run
 
-import com.google.container.tools.skaffold.getSkaffoldFileService
+import com.google.container.tools.skaffold.SkaffoldFileService
 import com.google.container.tools.skaffold.message
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.options.ConfigurationException
@@ -47,7 +47,7 @@ open class BaseSkaffoldSettingsEditor : SettingsEditor<RunConfiguration>() {
             skaffoldFilesComboBox.getItemAt(skaffoldFilesComboBox.selectedIndex)
                 ?: throw ConfigurationException(message("skaffold.no.file.selected.error"))
 
-        if (!getSkaffoldFileService().isSkaffoldFile(selectedSkaffoldFile)) {
+        if (!SkaffoldFileService.instance.isSkaffoldFile(selectedSkaffoldFile)) {
             throw ConfigurationException(message("skaffold.invalid.file.error"))
         }
     }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
@@ -16,7 +16,7 @@
 
 package com.google.container.tools.skaffold.run
 
-import com.google.container.tools.skaffold.getSkaffoldFileService
+import com.google.container.tools.skaffold.SkaffoldFileService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
@@ -42,7 +42,7 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
         setRenderer(VirtualFileRenderer(project.baseDir))
         skaffoldFilesMutableModel =
             DefaultComboBoxModel<VirtualFile>(
-                getSkaffoldFileService().findSkaffoldFiles(project).toTypedArray()
+                SkaffoldFileService.instance.findSkaffoldFiles(project).toTypedArray()
             )
         model = skaffoldFilesMutableModel
         if (model.size > 0) selectedIndex = 0

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
@@ -67,6 +67,7 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
         selectedItem = skaffoldFile
     }
 
+    /** Returns currently selected Skaffold file or null if none is selected. */
     fun getSelectedSkaffoldFile(): VirtualFile? =
         if (selectedIndex >= 0) model.getElementAt(selectedIndex) else null
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
@@ -16,7 +16,7 @@
 
 package com.google.container.tools.skaffold.run
 
-import com.google.container.tools.skaffold.findSkaffoldFiles
+import com.google.container.tools.skaffold.getSkaffoldFileService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
@@ -41,7 +41,9 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
     fun setProject(project: Project) {
         setRenderer(VirtualFileRenderer(project.baseDir))
         skaffoldFilesMutableModel =
-            DefaultComboBoxModel<VirtualFile>(findSkaffoldFiles(project).toTypedArray())
+            DefaultComboBoxModel<VirtualFile>(
+                getSkaffoldFileService().findSkaffoldFiles(project).toTypedArray()
+            )
         model = skaffoldFilesMutableModel
         if (model.size > 0) selectedIndex = 0
     }
@@ -54,6 +56,9 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
         skaffoldFilesMutableModel.addElement(skaffoldFile)
         selectedItem = skaffoldFile
     }
+
+    fun getSelectedSkaffoldFile(): VirtualFile? =
+        if (selectedIndex >= 0) model.getElementAt(selectedIndex) else null
 }
 
 /** Renders name of the Skaffold file relative to the base dir of the current IDE project. */

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
@@ -53,7 +53,17 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
      * the file, adds it and selects it.
      */
     fun setSelectedSkaffoldFile(skaffoldFile: VirtualFile) {
-        skaffoldFilesMutableModel.addElement(skaffoldFile)
+        var existingElement = false
+        for (i in 0..skaffoldFilesMutableModel.size) {
+            if (skaffoldFilesMutableModel.getElementAt(i) == skaffoldFile) {
+                existingElement = true
+                break
+            }
+        }
+        if (!existingElement) {
+            skaffoldFilesMutableModel.addElement(skaffoldFile)
+        }
+
         selectedItem = skaffoldFile
     }
 

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFileServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFileServiceTest.kt
@@ -23,17 +23,19 @@ import com.intellij.openapi.application.ApplicationManager
 import org.junit.Rule
 import org.junit.Test
 
-/** Unit tests for Skaffold files functionality in [SkaffoldFiles.kt] */
-class SkaffoldFilesTest {
+/** Unit tests for Skaffold files functionality in [SkaffoldFileService] */
+class SkaffoldFileServiceTest {
     @get:Rule
     val containerToolsRule = ContainerToolsRule(this)
+
+    private val skaffoldFileService = SkaffoldFileService()
 
     @Test
     fun `valid skaffold file is accepted`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         skaffoldFile.setText("apiVersion: skaffold/v1alpha2")
 
-        assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
+        assertThat(skaffoldFileService.isSkaffoldFile(skaffoldFile)).isTrue()
     }
 
     @Test
@@ -41,7 +43,7 @@ class SkaffoldFilesTest {
         val skaffoldFile = MockVirtualFile.file("tests-deploys.yaml")
         skaffoldFile.setText("apiVersion: skaffold/v1alpha3")
 
-        assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
+        assertThat(skaffoldFileService.isSkaffoldFile(skaffoldFile)).isTrue()
     }
 
     @Test
@@ -55,7 +57,7 @@ class SkaffoldFilesTest {
             """
         )
 
-        assertThat(isSkaffoldFile(skaffoldFile)).isTrue()
+        assertThat(skaffoldFileService.isSkaffoldFile(skaffoldFile)).isTrue()
     }
 
     @Test
@@ -63,7 +65,7 @@ class SkaffoldFilesTest {
         val k8sFile = MockVirtualFile.file("deploy.yaml")
         k8sFile.setText("apiVersion: apps/v1")
 
-        assertThat(isSkaffoldFile(k8sFile)).isFalse()
+        assertThat(skaffoldFileService.isSkaffoldFile(k8sFile)).isFalse()
     }
 
     @Test

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -26,7 +26,7 @@ import org.junit.Test
 /** Unit tests for Skaffold files functionality in [SkaffoldFiles.kt] */
 class SkaffoldFilesTest {
     @get:Rule
-    val containerToolsRule = ContainerToolsRule()
+    val containerToolsRule = ContainerToolsRule(this)
 
     @Test
     fun `valid skaffold file is accepted`() {

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldFilesTest.kt
@@ -69,9 +69,10 @@ class SkaffoldFilesTest {
     @Test
     fun `empty IDE project does not contain skaffold yaml files`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
+        val skaffoldFilesService = SkaffoldFileService()
 
         ApplicationManager.getApplication().runReadAction {
-            val skaffoldFiles = findSkaffoldFiles(project)
+            val skaffoldFiles = skaffoldFilesService.findSkaffoldFiles(project)
             assertThat(skaffoldFiles).isEmpty()
         }
     }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBoxTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBoxTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold.run
+
+import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.skaffold.SkaffoldFileService
+import com.google.container.tools.test.ContainerToolsRule
+import com.google.container.tools.test.TestService
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/** Unit tests for [SkaffoldFilesComboBox] */
+class SkaffoldFilesComboBoxTest {
+    @get:Rule
+    val containerToolsRule = ContainerToolsRule(this)
+
+    @MockK
+    @TestService
+    lateinit var mockSkaffoldFileService: SkaffoldFileService
+
+    private lateinit var skaffoldFilesComboBox: SkaffoldFilesComboBox
+
+    @Before
+    fun setUp() {
+        skaffoldFilesComboBox = SkaffoldFilesComboBox()
+    }
+
+    @Test
+    fun `empty combobox for empty project with no files`() {
+        val project = containerToolsRule.ideaProjectTestFixture.project
+        every { mockSkaffoldFileService.findSkaffoldFiles(project) } returns listOf()
+        skaffoldFilesComboBox.setProject(project)
+
+        assertThat(skaffoldFilesComboBox.getSelectedSkaffoldFile()).isNull()
+    }
+}

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBoxTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBoxTest.kt
@@ -34,7 +34,7 @@ class SkaffoldFilesComboBoxTest {
 
     @MockK
     @TestService
-    lateinit var mockSkaffoldFileService: SkaffoldFileService
+    private lateinit var mockSkaffoldFileService: SkaffoldFileService
 
     private lateinit var skaffoldFilesComboBox: SkaffoldFilesComboBox
 
@@ -44,7 +44,7 @@ class SkaffoldFilesComboBoxTest {
     }
 
     @Test
-    fun `empty combobox for empty project has no files`() {
+    fun `skaffold combo box for a project with no files has no elements and empty selection`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
         every { mockSkaffoldFileService.findSkaffoldFiles(project) } returns listOf()
         skaffoldFilesComboBox.setProject(project)

--- a/skaffold/src/test/resources/plugin.xml
+++ b/skaffold/src/test/resources/plugin.xml
@@ -14,12 +14,9 @@
   ~ limitations under the License.
   -->
 
-<!-- Declares IDE extensions and components for Skaffold support in Container Tools -->
-<idea-plugin>
-    <depends>org.jetbrains.plugins.yaml</depends>
-    <extensions defaultExtensionNs="com.intellij">
-        <configurationType implementation="com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType"/>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <id>com.google.container.tools</id>
+    <name>Google Container Tools</name>
 
-        <applicationService serviceImplementation="com.google.container.tools.skaffold.SkaffoldFileService"/>
-    </extensions>
+    <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>


### PR DESCRIPTION
Part of #19.
Work towards #12, #13.

In order to thouroughly test `SkaffoldComboBox` class and mock Skaffold files search across the project, Skaffold file search is now made an IDE service. 

To support testing/mocking it with combo box and for later unit tests, test service support (with annotation, similar to Cloud Tools approach) is added, along with support for Mockk mocking library, which seems to be the most popular choice for Kotlin unit tests as of now.