### PR TITLE
 Creates base config for both Skaffold run types to persist common Skaffold settings.

### DIFF
--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -48,19 +48,27 @@ class ContainerToolsRule(private val testInstance: Any) : TestRule {
             override fun evaluate() {
                 try {
                     setUpRule()
-                    baseStatement.evaluate()
+                    executeTest(baseStatement, description)
                 } finally {
                     tearDownRule()
                 }
             }
         }
 
+    private fun executeTest(baseStatement: Statement, description: Description) {
+        if (description.annotations.any { it is UiTest }) {
+            EdtTestUtil.runInEdtAndWait(ThrowableRunnable { baseStatement.evaluate() })
+        } else {
+            baseStatement.evaluate()
+        }
+    }
+
     private fun setUpRule() {
         ideaProjectTestFixture =
             IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().fixture
         EdtTestUtil.runInEdtAndWait(ThrowableRunnable { ideaProjectTestFixture.setUp() })
 
-        MockKAnnotations.init(testInstance, relaxUnitFun = true)
+        MockKAnnotations.init(testInstance, relaxed = true)
         replaceServices()
     }
 

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/ContainerToolsRule.kt
@@ -55,6 +55,7 @@ class ContainerToolsRule(private val testInstance: Any) : TestRule {
             }
         }
 
+    /** Checks the test method for additional annotations such as UI thread, and runs it. */
     private fun executeTest(baseStatement: Statement, description: Description) {
         if (description.annotations.any { it is UiTest }) {
             EdtTestUtil.runInEdtAndWait(ThrowableRunnable { baseStatement.evaluate() })

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestService.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestUtils.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/TestUtils.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.test
+
+import com.intellij.util.ThrowableRunnable
+import kotlin.reflect.KClass
+import kotlin.reflect.full.cast
+
+/**
+ * Asserts that the given [ThrowableRunnable] throws an exception of type
+ * `expectedThrowable` when executed.
+ *
+ * @param expectedThrowable the class of the exception that should be thrown
+ * @param runnable the [ThrowableRunnable] that should throw
+ * @param <T> the type of exception that should be thrown
+ * @return the thrown exception of type `expectedThrowable`
+ * @throws AssertionError if the given [ThrowableRunnable] throws a different type of
+ * exception or does not throw at all
+</T> */
+fun <T : Throwable> expectThrows(
+    expectedThrowable: KClass<T>,
+    runnable: ThrowableRunnable<T>
+): T {
+    try {
+        runnable.run()
+    } catch (thrown: Throwable) {
+        if (expectedThrowable.isInstance(thrown)) {
+            return expectedThrowable.cast(thrown)
+        }
+        val message = String.format(
+            "Unexpected exception type thrown; expected '%s' but was '%s'.",
+            expectedThrowable.simpleName, thrown::class.simpleName
+        )
+        throw AssertionError(message, thrown)
+    }
+
+    val message = String.format(
+        "Expected '%s' to be thrown, but nothing was thrown.",
+        expectedThrowable.simpleName
+    )
+    throw AssertionError(message)
+}

--- a/common-test-lib/src/main/kotlin/com/google/container/tools/test/UiTest.kt
+++ b/common-test-lib/src/main/kotlin/com/google/container/tools/test/UiTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.test
+
+/**
+ * Indicates that the annotated test method should be run on UI event dispatch thread (EDT).
+ * This annotation should be used for all unit tests that manipulate or create any Java Swing UI
+ * components or their children or other UI state, including all IDE platform components.
+ *
+ * This is used in conjunction with the [@Test][org.junit.Test] annotation to run the test method
+ * on EDT.
+ *
+ * ```
+ * @Test
+ * @UiTest
+ * fun manipulates_UI_components() { ... }
+ * ```
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class UiTest

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -31,7 +31,7 @@ import javax.swing.JComponent
  * drop-down list of all Skaffold configuration files ([SkaffoldFilesComboBox]) found
  * in the project and basic validation of the currently selected Skaffold file.
  */
-open class BaseSkaffoldSettingsEditor : SettingsEditor<BaseSkaffoldRunConfiguration>() {
+open class BaseSkaffoldSettingsEditor : SettingsEditor<AbstractSkaffoldRunConfiguration>() {
     @VisibleForTesting
     lateinit var skaffoldFilesComboBox: SkaffoldFilesComboBox
 
@@ -44,7 +44,7 @@ open class BaseSkaffoldSettingsEditor : SettingsEditor<BaseSkaffoldRunConfigurat
         return basePanel
     }
 
-    override fun applyEditorTo(runConfig: BaseSkaffoldRunConfiguration) {
+    override fun applyEditorTo(runConfig: AbstractSkaffoldRunConfiguration) {
         val selectedSkaffoldFile: VirtualFile =
             skaffoldFilesComboBox.getItemAt(skaffoldFilesComboBox.selectedIndex)
                 ?: throw ConfigurationException(message("skaffold.no.file.selected.error"))
@@ -57,7 +57,7 @@ open class BaseSkaffoldSettingsEditor : SettingsEditor<BaseSkaffoldRunConfigurat
         runConfig.skaffoldConfigurationFilePath = selectedSkaffoldFile.path
     }
 
-    override fun resetEditorFrom(runConfig: BaseSkaffoldRunConfiguration) {
+    override fun resetEditorFrom(runConfig: AbstractSkaffoldRunConfiguration) {
         skaffoldFilesComboBox.setProject(runConfig.project)
         runConfig.skaffoldConfigurationFilePath?.let {
             LocalFileSystem.getInstance().findFileByPath(it)

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -18,9 +18,9 @@ package com.google.container.tools.skaffold.run
 
 import com.google.container.tools.skaffold.SkaffoldFileService
 import com.google.container.tools.skaffold.message
-import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.layout.panel
 import javax.swing.JComponent
@@ -30,7 +30,7 @@ import javax.swing.JComponent
  * drop-down list of all Skaffold configuration files ([SkaffoldFilesComboBox]) found
  * in the project and basic validation of the currently selected Skaffold file.
  */
-open class BaseSkaffoldSettingsEditor : SettingsEditor<RunConfiguration>() {
+open class BaseSkaffoldSettingsEditor : SettingsEditor<BaseSkaffoldRunConfiguration>() {
     private lateinit var skaffoldFilesComboBox: SkaffoldFilesComboBox
 
     override fun createEditor(): JComponent {
@@ -42,7 +42,7 @@ open class BaseSkaffoldSettingsEditor : SettingsEditor<RunConfiguration>() {
         return basePanel
     }
 
-    override fun applyEditorTo(runConfig: RunConfiguration) {
+    override fun applyEditorTo(runConfig: BaseSkaffoldRunConfiguration) {
         val selectedSkaffoldFile: VirtualFile =
             skaffoldFilesComboBox.getItemAt(skaffoldFilesComboBox.selectedIndex)
                 ?: throw ConfigurationException(message("skaffold.no.file.selected.error"))
@@ -50,9 +50,15 @@ open class BaseSkaffoldSettingsEditor : SettingsEditor<RunConfiguration>() {
         if (!SkaffoldFileService.instance.isSkaffoldFile(selectedSkaffoldFile)) {
             throw ConfigurationException(message("skaffold.invalid.file.error"))
         }
+
+        // save properties
+        runConfig.skaffoldConfigurationFilePath = selectedSkaffoldFile.path
     }
 
-    override fun resetEditorFrom(runConfig: RunConfiguration) {
+    override fun resetEditorFrom(runConfig: BaseSkaffoldRunConfiguration) {
         skaffoldFilesComboBox.setProject(runConfig.project)
+        runConfig.skaffoldConfigurationFilePath?.let {
+            LocalFileSystem.getInstance().findFileByPath(it)
+        }?.let { skaffoldFilesComboBox.setSelectedSkaffoldFile(it) }
     }
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -16,6 +16,7 @@
 
 package com.google.container.tools.skaffold.run
 
+import com.google.common.annotations.VisibleForTesting
 import com.google.container.tools.skaffold.SkaffoldFileService
 import com.google.container.tools.skaffold.message
 import com.intellij.openapi.options.ConfigurationException
@@ -31,7 +32,8 @@ import javax.swing.JComponent
  * in the project and basic validation of the currently selected Skaffold file.
  */
 open class BaseSkaffoldSettingsEditor : SettingsEditor<BaseSkaffoldRunConfiguration>() {
-    private lateinit var skaffoldFilesComboBox: SkaffoldFilesComboBox
+    @VisibleForTesting
+    lateinit var skaffoldFilesComboBox: SkaffoldFilesComboBox
 
     override fun createEditor(): JComponent {
         skaffoldFilesComboBox = SkaffoldFilesComboBox()

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -72,7 +72,10 @@ abstract class BaseSkaffoldRunConfiguration(
     name: String
 ) : RunConfigurationBase(project, factory, name) {
 
-    /** Persisted Skaffold config file name for Skaffold run configurations. */
+    /**
+     * Persisted Skaffold config file absolute path for Skaffold run configurations.
+     * See more at [com.intellij.openapi.vfs.VirtualFile.getPath]
+     */
     @Attribute("skaffoldConfigurationFilePath")
     var skaffoldConfigurationFilePath: String? = null
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -71,7 +71,8 @@ abstract class BaseSkaffoldRunConfiguration(
     factory: ConfigurationFactory,
     name: String
 ) : RunConfigurationBase(project, factory, name) {
-    /** Persisted Skaffold config file name for run Skaffold run configurations. */
+
+    /** Persisted Skaffold config file name for Skaffold run configurations. */
     @Attribute("skaffoldConfigurationFilePath")
     var skaffoldConfigurationFilePath: String? = null
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -24,6 +24,7 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
+import com.intellij.util.xmlb.annotations.Attribute
 
 /**
  * Template configuration for Skaffold single run configuration, serving as a base for all new
@@ -34,7 +35,7 @@ class SkaffoldSingleRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : RunConfigurationBase(project, factory, name) {
+) : BaseSkaffoldRunConfiguration(project, factory, name) {
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? =
         null
@@ -52,11 +53,25 @@ class SkaffoldDevConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : RunConfigurationBase(project, factory, name) {
+) : BaseSkaffoldRunConfiguration(project, factory, name) {
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? =
         null
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =
         SkaffoldDevSettingsEditor()
+}
+
+/**
+ * Base class for Skaffold run configurations, includes base properties such as Skaffold
+ * configuration file path.
+ */
+abstract class BaseSkaffoldRunConfiguration(
+    project: Project,
+    factory: ConfigurationFactory,
+    name: String
+) : RunConfigurationBase(project, factory, name) {
+    /** Persisted Skaffold config file name for run Skaffold run configurations. */
+    @Attribute("skaffoldConfigurationFilePath")
+    var skaffoldConfigurationFilePath: String? = null
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -35,7 +35,7 @@ class SkaffoldSingleRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : BaseSkaffoldRunConfiguration(project, factory, name) {
+) : AbstractSkaffoldRunConfiguration(project, factory, name) {
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? =
         null
@@ -53,7 +53,7 @@ class SkaffoldDevConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : BaseSkaffoldRunConfiguration(project, factory, name) {
+) : AbstractSkaffoldRunConfiguration(project, factory, name) {
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? =
         null
@@ -66,7 +66,7 @@ class SkaffoldDevConfiguration(
  * Base class for Skaffold run configurations, includes base properties such as Skaffold
  * configuration file path.
  */
-abstract class BaseSkaffoldRunConfiguration(
+abstract class AbstractSkaffoldRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
@@ -21,6 +21,7 @@ import com.google.container.tools.skaffold.SkaffoldFileService
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.google.container.tools.test.UiTest
+import com.google.container.tools.test.expectThrows
 import com.intellij.mock.MockVirtualFile
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.testFramework.EdtTestUtil
@@ -64,21 +65,25 @@ class BaseSkaffoldSettingsEditorTest {
             { containerToolsRule.ideaProjectTestFixture.project }
     }
 
-    @Test(expected = ConfigurationException::class)
+    @Test
     @UiTest
     fun `settings are invalid for project with no existing Skaffold files`() {
         baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
 
-        baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings)
+        expectThrows(
+            ConfigurationException::class,
+            ThrowableRunnable { baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings) })
     }
 
-    @Test(expected = ConfigurationException::class)
+    @Test
     @UiTest
     fun `settings are invalid for non-existing Skaffold file`() {
         every { mockSkaffoldSettings.skaffoldConfigurationFilePath } answers { "no-such-file.yaml" }
         baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
 
-        baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings)
+        expectThrows(
+            ConfigurationException::class,
+            ThrowableRunnable { baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings) })
     }
 
     @Test

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold.run
+
+import com.google.container.tools.skaffold.SkaffoldFileService
+import com.google.container.tools.test.ContainerToolsRule
+import com.google.container.tools.test.TestService
+import com.google.container.tools.test.UiTest
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.testFramework.EdtTestUtil
+import com.intellij.util.ThrowableRunnable
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Unit tests for base Skaffold settings support defined in [BaseSkaffoldSettingsEditor] and
+ * [BaseSkaffoldRunConfiguration].
+ */
+class BaseSkaffoldSettingsEditorTest {
+    @get:Rule
+    val containerToolsRule = ContainerToolsRule(this)
+
+    @MockK
+    @TestService
+    private lateinit var mockSkaffoldFileService: SkaffoldFileService
+
+    @MockK
+    private lateinit var mockSkaffoldSettings: BaseSkaffoldRunConfiguration
+
+    private lateinit var baseSkaffoldSettingsEditor: BaseSkaffoldSettingsEditor
+
+    @Before
+    fun setUp() {
+        EdtTestUtil.runInEdtAndWait(ThrowableRunnable {
+            baseSkaffoldSettingsEditor = BaseSkaffoldSettingsEditor()
+            // calls getComponent() to initialize UI first, IDE flow.
+            baseSkaffoldSettingsEditor.component
+        })
+
+        // default is project with no Skaffold files
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf()
+        // return test fixture project for settings
+        every { mockSkaffoldSettings.project } answers
+            { containerToolsRule.ideaProjectTestFixture.project }
+    }
+
+    @Test(expected = ConfigurationException::class)
+    @UiTest
+    fun `settings are invalid for project with no existing Skaffold files`() {
+        baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
+
+        baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings)
+    }
+
+    @Test(expected = ConfigurationException::class)
+    @UiTest
+    fun `settings are invalid for non-existing Skaffold files`() {
+        every { mockSkaffoldSettings.skaffoldConfigurationFilePath } answers { "no-such-file.yaml" }
+        baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
+
+        baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings)
+    }
+}

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
@@ -67,7 +67,7 @@ class BaseSkaffoldSettingsEditorTest {
 
     @Test
     @UiTest
-    fun `settings are invalid for project with no existing Skaffold files`() {
+    fun `when project has no Skaffold files resetFrom throws a ConfigurationException`() {
         baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
 
         expectThrows(
@@ -77,7 +77,7 @@ class BaseSkaffoldSettingsEditorTest {
 
     @Test
     @UiTest
-    fun `settings are invalid for non-existing Skaffold file`() {
+    fun `given non-existing Skaffold file resetFrom throws a ConfigurationException`() {
         every { mockSkaffoldSettings.skaffoldConfigurationFilePath } answers { "no-such-file.yaml" }
         baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
 
@@ -88,7 +88,7 @@ class BaseSkaffoldSettingsEditorTest {
 
     @Test
     @UiTest
-    fun `editor successfully saves selected valid Skaffold configuration file`() {
+    fun `given valid Skaffold configuration file applyTo successfully saves settings`() {
         val skaffoldFile = MockVirtualFile.file("tests-deploy.yaml")
         skaffoldFile.setText("apiVersion: skaffold/v1alpha3")
         every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf(skaffoldFile)

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
@@ -86,7 +86,7 @@ class BaseSkaffoldSettingsEditorTest {
     fun `editor successfully saves selected valid Skaffold configuration file`() {
         val skaffoldFile = MockVirtualFile.file("tests-deploy.yaml")
         skaffoldFile.setText("apiVersion: skaffold/v1alpha3")
-        every { mockSkaffoldFileService.findSkaffoldFiles(any())} returns listOf(skaffoldFile)
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf(skaffoldFile)
         baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
         baseSkaffoldSettingsEditor.skaffoldFilesComboBox.setSelectedSkaffoldFile(skaffoldFile)
         baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings)

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
@@ -35,7 +35,7 @@ import org.junit.Test
 
 /**
  * Unit tests for base Skaffold settings support defined in [BaseSkaffoldSettingsEditor] and
- * [BaseSkaffoldRunConfiguration].
+ * [AbstractSkaffoldRunConfiguration].
  */
 class BaseSkaffoldSettingsEditorTest {
     @get:Rule
@@ -46,7 +46,7 @@ class BaseSkaffoldSettingsEditorTest {
     private var mockSkaffoldFileService: SkaffoldFileService = SkaffoldFileService()
 
     @MockK
-    private lateinit var mockSkaffoldSettings: BaseSkaffoldRunConfiguration
+    private lateinit var mockSkaffoldSettings: AbstractSkaffoldRunConfiguration
 
     private lateinit var baseSkaffoldSettingsEditor: BaseSkaffoldSettingsEditor
 

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBoxTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBoxTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.container.tools.skaffold.SkaffoldFileService
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
+import com.google.container.tools.test.UiTest
 import com.intellij.mock.MockVirtualFile
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -44,6 +45,7 @@ class SkaffoldFilesComboBoxTest {
     }
 
     @Test
+    @UiTest
     fun `skaffold combo box for a project with no files has no elements and empty selection`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
         every { mockSkaffoldFileService.findSkaffoldFiles(project) } returns listOf()
@@ -53,6 +55,7 @@ class SkaffoldFilesComboBoxTest {
     }
 
     @Test
+    @UiTest
     fun `single skaffold file from project is pre-selected in combo box`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
         val mockSkaffoldFile = MockVirtualFile.file("skaffold.yaml")
@@ -64,6 +67,7 @@ class SkaffoldFilesComboBoxTest {
     }
 
     @Test
+    @UiTest
     fun `first skaffold file from multi-file project is pre-selected in combo box`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
         val mockSkaffoldFile1 = MockVirtualFile.file("k8s/deploy.yaml")
@@ -78,6 +82,7 @@ class SkaffoldFilesComboBoxTest {
     }
 
     @Test
+    @UiTest
     fun `setSelectedSkaffoldFile with existing file changes selection in combo box`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
         val mockSkaffoldFile1 = MockVirtualFile.file("k8s/deploy.yaml")
@@ -95,6 +100,7 @@ class SkaffoldFilesComboBoxTest {
     }
 
     @Test
+    @UiTest
     fun `setSelectedSkaffoldFile with non-existing file changes selection and adds element`() {
         val project = containerToolsRule.ideaProjectTestFixture.project
         val mockSkaffoldFile1 = MockVirtualFile.file("k8s/deploy.yaml")


### PR DESCRIPTION
Work towards #12, #13.
Part of #19.

Adds base run configuration (`BaseSkaffoldRunConfiguration`) which includes persisted attribute to store saved Skaffold configuration file between restarts and changes.
Includes test for base settings editor that uses this configuration settings.

For unit tests, introduces `@UiTest` annotation to allow individual tests to run on UI thread, if they manipulate or access UI components or related state to avoid possible unit test flakiness.

