### PR TITLE
 Adds Skaffold executor service to build Skaffold commands and execute process.

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -16,6 +16,23 @@
 
 package com.google.container.tools.skaffold
 
-class SkaffoldExecutorService {
-    
+class DefaultSkaffoldExecutorService : SkaffoldExecutorService {
+    override var skaffoldConfigurationFilePath: String?
+        get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+        set(value) {}
+
+    override fun executeSingleRun() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun executeDevMode() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}
+
+interface SkaffoldExecutorService {
+    var skaffoldConfigurationFilePath: String?
+
+    fun executeSingleRun()
+    fun executeDevMode()
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -17,21 +17,27 @@
 package com.google.container.tools.skaffold
 
 import com.google.common.annotations.VisibleForTesting
+import com.google.container.tools.skaffold.SkaffoldExecutorSettings.ExecutionMode
 import com.intellij.openapi.components.ServiceManager
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
- * Interface for Skaffold execution service. This service builds and launches Skaffold process from
- * the given set of standard flags and settings. [DefaultSkaffoldExecutorService] assumes Skaffold
- * to be already installed and available.
+ * Abstract implementation for Skaffold execution service. This service builds and launches Skaffold
+ * process from the given set of standard flags and settings.
+ * Constructs Skaffold command line and build resulting process.
+ * Path to Skaffold executable must be set by subclasses.
+ * [DefaultSkaffoldExecutorService] assumes Skaffold to be already installed and available.
  */
-interface SkaffoldExecutorService {
+abstract class SkaffoldExecutorService {
     companion object {
         val instance
             get() = ServiceManager.getService(SkaffoldExecutorService::class.java)!!
     }
+
+    /** Path for Skaffold executable, any form supported by [ProcessBuilder] */
+    protected abstract var skaffoldExecutablePath: Path
 
     /**
      * Creates Skaffold command line from the given settings and returns resulting launched
@@ -40,50 +46,8 @@ interface SkaffoldExecutorService {
      * @param settings Settings with flags supported by Skaffold.
      * @return [SkaffoldProcess] with resulting process and the command line used to launch it.
      */
-    fun executeSkaffold(settings: SkaffoldExecutorSettings): SkaffoldProcess
-
-    /**
-     * Execution mode for Skaffold, single run, continuous development, etc.
-     */
-    enum class SkaffoldExecutionMode(val modeFlag: String) {
-        SINGLE_RUN("run"),
-        DEV("dev")
-    }
-
-    /**
-     * Set of settings to control Skaffold execution, including flags and execution mode.
-     *
-     * @property executionMode Mandatory execution mode for Skaffold, see [SkaffoldExecutionMode].
-     * @property skaffoldConfigurationFilePath Optional, location of the Skaffold YAML
-     *           configuration file. If not provided, default `skaffold.yaml` used.
-     * @property workingDirectory Optional, working directory where Skaffold needs to be launched.
-     *           This is usually set to project working directory.
-     */
-    data class SkaffoldExecutorSettings(
-        val executionMode: SkaffoldExecutionMode,
-        val skaffoldConfigurationFilePath: String? = null,
-        var workingDirectory: File? = null
-    )
-
-    /**
-     * Data object with launched Skaffold process and its command line.
-     *
-     * @property process System process for Skaffold.
-     * @property commandLine Command line used to launch the process.
-     */
-    data class SkaffoldProcess(val process: Process, val commandLine: String)
-}
-
-/**
- * Abstract implementation of [SkaffoldExecutorService], constructs Skaffold command line and
- * build resulting process. Path to Skaffold executable must be set by subclasses.
- */
-abstract class AbstractSkaffoldExecutorService : SkaffoldExecutorService {
-    /** Path for Skaffold executable, any form supported by [ProcessBuilder] */
-    protected abstract var skaffoldExecutablePath: Path
-
-    override fun executeSkaffold(settings: SkaffoldExecutorService.SkaffoldExecutorSettings):
-        SkaffoldExecutorService.SkaffoldProcess {
+    fun executeSkaffold(settings: SkaffoldExecutorSettings):
+        SkaffoldProcess {
         val commandList = mutableListOf<String>()
         with(commandList) {
             add(skaffoldExecutablePath.toString())
@@ -94,7 +58,7 @@ abstract class AbstractSkaffoldExecutorService : SkaffoldExecutorService {
             }
         }
 
-        return SkaffoldExecutorService.SkaffoldProcess(
+        return SkaffoldProcess(
             createProcess(settings.workingDirectory, commandList),
             commandLine = commandList.joinToString(" ")
         )
@@ -113,10 +77,40 @@ abstract class AbstractSkaffoldExecutorService : SkaffoldExecutorService {
 }
 
 /**
+ * Set of settings to control Skaffold execution, including flags and execution mode.
+ *
+ * @property executionMode Mandatory execution mode for Skaffold, see [ExecutionMode].
+ * @property skaffoldConfigurationFilePath Optional, location of the Skaffold YAML
+ *           configuration file. If not provided, default `skaffold.yaml` used.
+ * @property workingDirectory Optional, working directory where Skaffold needs to be launched.
+ *           This is usually set to project working directory.
+ */
+data class SkaffoldExecutorSettings(
+    val executionMode: ExecutionMode,
+    val skaffoldConfigurationFilePath: String? = null,
+    var workingDirectory: File? = null
+) {
+
+    /** Execution mode for Skaffold, single run, continuous development, etc. */
+    enum class ExecutionMode(val modeFlag: String) {
+        SINGLE_RUN("run"),
+        DEV("dev")
+    }
+}
+
+/**
+ * Data object with launched Skaffold process and its command line.
+ *
+ * @property process System process for Skaffold.
+ * @property commandLine Command line used to launch the process.
+ */
+data class SkaffoldProcess(val process: Process, val commandLine: String)
+
+/**
  * Default implementation of Skaffold execution service, where Skaffold executable is assumed to
  * be already installed on the system and be available in PATH.
  */
-class DefaultSkaffoldExecutorService : AbstractSkaffoldExecutorService() {
+class DefaultSkaffoldExecutorService : SkaffoldExecutorService() {
     // use executable available in PATH
     override var skaffoldExecutablePath: Path = Paths.get("skaffold")
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -52,19 +52,16 @@ interface SkaffoldExecutorService {
 
     /**
      * Set of settings to control Skaffold execution, including flags and execution mode.
+     *
+     * @property executionMode Mandatory execution mode for Skaffold, see [SkaffoldExecutionMode].
+     * @property skaffoldConfigurationFilePath Optional, location of the Skaffold YAML
+     *           configuration file. If not provided, default `skaffold.yaml` used.
+     * @property workingDirectory Optional, working directory where Skaffold needs to be launched.
+     *           This is usually set to project working directory.
      */
     data class SkaffoldExecutorSettings(
-        /** Mandatory execution mode for Skaffold, see [SkaffoldExecutionMode]. */
         val executionMode: SkaffoldExecutionMode,
-        /**
-         * Optional, location of the Skaffold YAML configuration file.
-         * If not provided, default `skaffold.yaml` used.
-         */
         val skaffoldConfigurationFilePath: String? = null,
-        /**
-         * Optional, working directory where Skaffold needs to be launched. This is usually set to
-         * project working directory.
-         */
         var workingDirectory: File? = null
     )
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold
+
+class SkaffoldExecutorService {
+    
+}

--- a/skaffold/src/main/resources/META-INF/skaffold.xml
+++ b/skaffold/src/main/resources/META-INF/skaffold.xml
@@ -18,10 +18,14 @@
 <idea-plugin>
     <depends>org.jetbrains.plugins.yaml</depends>
     <extensions defaultExtensionNs="com.intellij">
-        <configurationType implementation="com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType"/>
+        <configurationType
+                implementation="com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType"/>
 
-        <applicationService serviceImplementation="com.google.container.tools.skaffold.SkaffoldFileService"/>
+        <applicationService
+                serviceImplementation="com.google.container.tools.skaffold.SkaffoldFileService"/>
 
-        <applicationService serviceImplementation="com.google.container.tools.skaffold.SkaffoldExecutorService"/>
+        <applicationService
+                serviceInterface="com.google.container.tools.skaffold.SkaffoldExecutorService"
+                serviceImplementation="com.google.container.tools.skaffold.DefaultSkaffoldExecutorService"/>
     </extensions>
 </idea-plugin>

--- a/skaffold/src/main/resources/META-INF/skaffold.xml
+++ b/skaffold/src/main/resources/META-INF/skaffold.xml
@@ -21,5 +21,7 @@
         <configurationType implementation="com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType"/>
 
         <applicationService serviceImplementation="com.google.container.tools.skaffold.SkaffoldFileService"/>
+
+        <applicationService serviceImplementation="com.google.container.tools.skaffold.SkaffoldExecutorService"/>
     </extensions>
 </idea-plugin>

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -21,9 +21,11 @@ import com.google.container.tools.test.ContainerToolsRule
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.io.File
 
 /** Unit tests for [DefaultSkaffoldExecutorService] and [AbstractSkaffoldExecutorService] */
 class DefaultSkaffoldExecutorServiceTest {
@@ -73,5 +75,18 @@ class DefaultSkaffoldExecutorServiceTest {
         )
 
         assertThat(result.commandLine).isEqualTo("skaffold dev --filename test.yaml")
+    }
+
+    @Test
+    fun `working directory is passed on to process builder`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorService.SkaffoldExecutorSettings(
+                SkaffoldExecutorService.SkaffoldExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml",
+                workingDirectory = File("/tmp")
+            )
+        )
+
+        verify { defaultSkaffoldExecutorService.createProcess(File("/tmp"), any()) }
     }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -27,7 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.io.File
 
-/** Unit tests for [DefaultSkaffoldExecutorService] and [AbstractSkaffoldExecutorService] */
+/** Unit tests for [DefaultSkaffoldExecutorService] and [SkaffoldExecutorService] */
 class DefaultSkaffoldExecutorServiceTest {
     @get:Rule
     val containerToolsRule = ContainerToolsRule(this)
@@ -46,8 +46,8 @@ class DefaultSkaffoldExecutorServiceTest {
     @Test
     fun `single run with no arguments launches skaffold run`() {
         val result = defaultSkaffoldExecutorService.executeSkaffold(
-            SkaffoldExecutorService.SkaffoldExecutorSettings(
-                SkaffoldExecutorService.SkaffoldExecutionMode.SINGLE_RUN
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.SINGLE_RUN
             )
         )
 
@@ -57,8 +57,8 @@ class DefaultSkaffoldExecutorServiceTest {
     @Test
     fun `dev mode with no arguments launches skaffold dev`() {
         val result = defaultSkaffoldExecutorService.executeSkaffold(
-            SkaffoldExecutorService.SkaffoldExecutorSettings(
-                SkaffoldExecutorService.SkaffoldExecutionMode.DEV
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV
             )
         )
 
@@ -68,8 +68,8 @@ class DefaultSkaffoldExecutorServiceTest {
     @Test
     fun `skaffold config filename argument generates valid skaffold filename flag`() {
         val result = defaultSkaffoldExecutorService.executeSkaffold(
-            SkaffoldExecutorService.SkaffoldExecutorSettings(
-                SkaffoldExecutorService.SkaffoldExecutionMode.DEV,
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
                 skaffoldConfigurationFilePath = "test.yaml"
             )
         )
@@ -79,9 +79,9 @@ class DefaultSkaffoldExecutorServiceTest {
 
     @Test
     fun `working directory is passed on to process builder`() {
-        val result = defaultSkaffoldExecutorService.executeSkaffold(
-            SkaffoldExecutorService.SkaffoldExecutorSettings(
-                SkaffoldExecutorService.SkaffoldExecutionMode.DEV,
+        defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
                 skaffoldConfigurationFilePath = "test.yaml",
                 workingDirectory = File("/tmp")
             )

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold
+
+import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.test.ContainerToolsRule
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/** Unit tests for [DefaultSkaffoldExecutorService] and [AbstractSkaffoldExecutorService] */
+class DefaultSkaffoldExecutorServiceTest {
+    @get:Rule
+    val containerToolsRule = ContainerToolsRule(this)
+
+    private lateinit var defaultSkaffoldExecutorService: DefaultSkaffoldExecutorService
+
+    @MockK
+    private lateinit var mockProcess: Process
+
+    @Before
+    fun setUp() {
+        defaultSkaffoldExecutorService = spyk(DefaultSkaffoldExecutorService())
+        every { defaultSkaffoldExecutorService.createProcess(any(), any()) } answers { mockProcess }
+    }
+
+    @Test
+    fun `single run with no arguments launches skaffold run`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorService.SkaffoldExecutorSettings(
+                SkaffoldExecutorService.SkaffoldExecutionMode.SINGLE_RUN
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold run")
+    }
+
+    @Test
+    fun `dev mode with no arguments launches skaffold dev`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorService.SkaffoldExecutorSettings(
+                SkaffoldExecutorService.SkaffoldExecutionMode.DEV
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold dev")
+    }
+
+    @Test
+    fun `skaffold config filename argument generates valid skaffold filename flag`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorService.SkaffoldExecutorSettings(
+                SkaffoldExecutorService.SkaffoldExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml"
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold dev --filename test.yaml")
+    }
+}


### PR DESCRIPTION
Progress towards #12, #13.

Creates a service that constructs Skaffold command line and launches system process based on the resulting command line. Service is defined with an interface. Default implementation assumes Skaffold is already installed and present in PATH on the system (current behavior for command line users.)

Next PR will use this service to start processes based on run configurations.
The service interface is also going to be used when Skaffold managed installation implementation is complete and will be used to execute Skaffold using managed binary.