### PR TITLE
Creates new skaffold-editing module and live template

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,8 +2,12 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
+      <module name="common-test-lib_main" target="1.8" />
+      <module name="common-test-lib_test" target="1.8" />
       <module name="google-container-tools-intellij_main" target="1.8" />
       <module name="google-container-tools-intellij_test" target="1.8" />
+      <module name="skaffold-editing_main" target="1.8" />
+      <module name="skaffold-editing_test" target="1.8" />
       <module name="skaffold_main" target="1.8" />
       <module name="skaffold_test" target="1.8" />
     </bytecodeTargetLevel>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,4 +67,5 @@ allprojects {
 
 dependencies {
     compile(project(":skaffold"))
+    compile(project(":skaffold-editing"))
 }

--- a/skaffold-editing/build.gradle.kts
+++ b/skaffold-editing/build.gradle.kts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-include 'skaffold'
-include 'skaffold-editing'
-include 'common-test-lib'
+dependencies {
+    compile(project(":common-test-lib"))
+}

--- a/skaffold-editing/src/main/kotlin/com/google/container/tools/skaffold/editing/SkaffoldContextType.kt
+++ b/skaffold-editing/src/main/kotlin/com/google/container/tools/skaffold/editing/SkaffoldContextType.kt
@@ -1,0 +1,25 @@
+package com.google.container.tools.skaffold.editing
+
+import com.intellij.codeInsight.template.TemplateContextType
+import com.intellij.psi.PsiFile
+
+private const val SKAFFOLD_TEMPLATE_ID = "SKAFFOLD"
+private const val SKAFFOLD_TEMPLATE_NAME = "Skaffold"
+
+/**
+ * Defines the [TemplateContextType] for Skaffold files.
+ */
+class SkaffoldContextType(
+    id: String = SKAFFOLD_TEMPLATE_ID,
+    presentableName: String = SKAFFOLD_TEMPLATE_NAME
+) :
+    TemplateContextType(id, presentableName) {
+
+    /**
+     * A file is in context for Skaffold live templates if it is a yaml file.
+     */
+    override fun isInContext(file: PsiFile, offset: Int): Boolean {
+        return file.name.endsWith(suffix = "yaml", ignoreCase = true)
+            || file.name.endsWith(suffix = "yml", ignoreCase = true)
+    }
+}

--- a/skaffold-editing/src/main/kotlin/com/google/container/tools/skaffold/editing/SkaffoldLiveTemplatesProvider.kt
+++ b/skaffold-editing/src/main/kotlin/com/google/container/tools/skaffold/editing/SkaffoldLiveTemplatesProvider.kt
@@ -1,0 +1,20 @@
+package com.google.container.tools.skaffold.editing
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider
+
+private const val SKAFFOLD_LIVE_TEMPLATE_PATH = "liveTemplates/Skaffold"
+
+/**
+ * A Skaffold [DefaultLiveTemplatesProvider] that provides the live templates used for generating /
+ * editing Skaffold configuration files.
+ */
+class SkaffoldLiveTemplatesProvider : DefaultLiveTemplatesProvider {
+
+    override fun getDefaultLiveTemplateFiles(): Array<String> {
+        return arrayOf(SKAFFOLD_LIVE_TEMPLATE_PATH)
+    }
+
+    override fun getHiddenLiveTemplateFiles(): Array<String>? {
+        return emptyArray()
+    }
+}

--- a/skaffold-editing/src/main/resources/META-INF/skaffold-editing.xml
+++ b/skaffold-editing/src/main/resources/META-INF/skaffold-editing.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Google Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <liveTemplateContext implementation="com.google.container.tools.skaffold.editing.SkaffoldContextType"/>
+        <defaultLiveTemplatesProvider
+                implementation="com.google.container.tools.skaffold.editing.SkaffoldLiveTemplatesProvider"/>
+    </extensions>
+</idea-plugin>

--- a/skaffold-editing/src/main/resources/liveTemplates/Skaffold.xml
+++ b/skaffold-editing/src/main/resources/liveTemplates/Skaffold.xml
@@ -1,0 +1,8 @@
+<templateSet group="Skaffold">
+  <template name="skaffold" value="apiVersion: apps/v1alpha4&#10;kind: Config&#10;build:&#10;  artifacts:&#10;    - image: $IMAGE$ &#10;deploy:&#10;  kubectl:&#10;      manifests:&#10;     - $MANIFEST$&#10;    &#10;" description="Skaffold Config" toReformat="true" toShortenFQNames="true">
+    <variable name="IMAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="SKAFFOLD" value="true" />
+    </context>
+  </template>
+</templateSet>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,5 +25,6 @@
     <idea-version since-build="171.3780" until-build="182.*"/>
 
     <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <xi:include href="/META-INF/skaffold-editing.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
 </idea-plugin>


### PR DESCRIPTION
-  Creates a new `skaffold-editing` module to house the editing generation support
- Sets up a new live template for skaffold configs. The config is currently hardcoded in the `Skaffold.xml` live template config file. As is, we would need to update it to keep up with Skaffold version / api changes. We can look into enhancing this to be more dynamic in subsequent PRs.

How it works in the IDE:

user types in the live template keyword as usual (in this case its `skaffold`):
![image](https://user-images.githubusercontent.com/1735744/47513950-4ebeab00-d84d-11e8-9ef1-204793b716bb.png)

selecting the template generates a starter config:
![image](https://user-images.githubusercontent.com/1735744/47514012-6bf37980-d84d-11e8-846f-63ec75e8dc7e.png)

