### PR TITLE
Expand version range to include upcoming 2018.3 IDE, allow older IDEs to use the plugin.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ allprojects {
         type = project.properties["ideaEdition"].toString()
         version = project.properties["ideaVersion"].toString()
         intellijRepo = project.properties["intellijRepoUrl"].toString()
+        updateSinceUntilBuild = false
     }
 
     tasks.withType<KotlinCompile> {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
     <name>Google Container Tools</name>
     <vendor>Google</vendor>
 
-    <!-- "idea-version since-build" set to cover 2017.1 - 2018.2 -->
+    <!-- "idea-version since-build" set to cover 2017.1 - 2018.3 -->
     <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->
     <idea-version since-build="171.3780" until-build="183.*"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,7 +22,7 @@
 
     <!-- "idea-version since-build" set to cover 2017.1 - 2018.2 -->
     <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->
-    <idea-version since-build="171.3780" until-build="182.*"/>
+    <idea-version since-build="171.3780" until-build="183.*"/>
 
     <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/skaffold-editing.xml" xpointer="xpointer(/idea-plugin/*)"/>


### PR DESCRIPTION
IntelliJ Gradle plugin was enforcing minimum version of the IDE used to build it (2018.2+) to run the plugin if `updateSinceUntilBuild` property is not set to `false`.