### PR TITLE
Made sure IntelliJ run target runs IDE only once for root plugin.

### DIFF
--- a/.idea/runConfigurations/Google_Container_Tools.xml
+++ b/.idea/runConfigurations/Google_Container_Tools.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="runIde" />
+          <option value=":runIde" />
         </list>
       </option>
       <option name="vmOptions" value="" />


### PR DESCRIPTION
Currently it runs `runIde` sequentially for all sub-projects.