### PR TITLE
Added lang module dependency to enable run configurations in non-Java IDEs.

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,8 @@
     <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->
     <idea-version since-build="171.3780" until-build="183.*"/>
 
+    <depends>com.intellij.modules.lang</depends>
+
     <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/skaffold-editing.xml" xpointer="xpointer(/idea-plugin/*)"/>
 


### PR DESCRIPTION
While testing non-Java IDEs it turns out the run configurations are not loaded if plugin does not declare `lang` module dependency (same as previous Cloud Tools plugin). Adding the dependency enables the run configurations.