### PR TITLE
 Provides custom plugin labels for all Skaffold deployments for server-side metrics.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2018 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 dependencies {
     testCompile(project(":common-test-lib"))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,7 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 dependencies {
-    compile(project(":core"))
     testCompile(project(":common-test-lib"))
 }

--- a/core/src/main/kotlin/com/google/container/tools/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/PluginInfo.kt
@@ -23,9 +23,14 @@ import com.intellij.openapi.extensions.PluginId
 const val CONTAINER_TOOLS_PLUGIN_ID = "com.google.container.tools"
 const val UNKNOWN_VERSION = "N/A"
 
-fun getPluginVersion(): String {
-    val ideaPluginDescriptor: IdeaPluginDescriptor? =
-        PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
+/** Utilities to get common plugin information such as its version. */
+object PluginInfo {
 
-    return ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
+    /** Returns version of the plugin installed, or `N/A` if version cannot be determined. */
+    fun getPluginVersion(): String {
+        val ideaPluginDescriptor: IdeaPluginDescriptor? =
+            PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
+
+        return ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
+    }
 }

--- a/core/src/main/kotlin/com/google/container/tools/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/PluginInfo.kt
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 
-dependencies {
-    compile(project(":core"))
-    testCompile(project(":common-test-lib"))
+package com.google.container.tools
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.extensions.PluginId
+
+const val CONTAINER_TOOLS_PLUGIN_ID = "com.google.container.tools"
+const val UNKNOWN_VERSION = "N/A"
+
+fun getPluginVersion(): String {
+    val ideaPluginDescriptor: IdeaPluginDescriptor? =
+        PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
+
+    return ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
 }

--- a/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
@@ -19,6 +19,7 @@ package com.google.container.tools.core
 import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
+import com.intellij.util.PlatformUtils
 
 const val CONTAINER_TOOLS_PLUGIN_ID = "com.google.container.tools"
 const val UNKNOWN = "N/A"
@@ -34,4 +35,6 @@ object PluginInfo {
 
             return ideaPluginDescriptor?.version ?: UNKNOWN
         }
+
+    fun getPlatformPrefix(): String = PlatformUtils.getPlatformPrefix()
 }

--- a/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
@@ -18,6 +18,7 @@ package com.google.container.tools.core
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.util.PlatformUtils
 
@@ -25,7 +26,11 @@ const val CONTAINER_TOOLS_PLUGIN_ID = "com.google.container.tools"
 const val UNKNOWN_VERSION = "unknown"
 
 /** Utilities to get common plugin information such as its version. */
-object PluginInfo {
+class PluginInfo {
+    companion object {
+        val instance: PluginInfo
+            get() = ServiceManager.getService(PluginInfo::class.java)!!
+    }
 
     /** Version of the plugin installed, or `N/A` if version cannot be determined. */
     val pluginVersion: String by lazy {

--- a/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
@@ -36,5 +36,5 @@ object PluginInfo {
             return ideaPluginDescriptor?.version ?: UNKNOWN
         }
 
-    fun getPlatformPrefix(): String = PlatformUtils.getPlatformPrefix()
+    val platformPrefix: String = PlatformUtils.getPlatformPrefix()
 }

--- a/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.container.tools
+package com.google.container.tools.core
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginManager
@@ -26,11 +26,12 @@ const val UNKNOWN_VERSION = "N/A"
 /** Utilities to get common plugin information such as its version. */
 object PluginInfo {
 
-    /** Returns version of the plugin installed, or `N/A` if version cannot be determined. */
-    fun getPluginVersion(): String {
-        val ideaPluginDescriptor: IdeaPluginDescriptor? =
-            PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
+    /** Version of the plugin installed, or `N/A` if version cannot be determined. */
+    val pluginVersion: String
+        get() {
+            val ideaPluginDescriptor: IdeaPluginDescriptor? =
+                PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
 
-        return ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
-    }
+            return ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
+        }
 }

--- a/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
@@ -22,19 +22,18 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.util.PlatformUtils
 
 const val CONTAINER_TOOLS_PLUGIN_ID = "com.google.container.tools"
-const val UNKNOWN = "N/A"
+const val UNKNOWN_VERSION = "unknown"
 
 /** Utilities to get common plugin information such as its version. */
 object PluginInfo {
 
     /** Version of the plugin installed, or `N/A` if version cannot be determined. */
-    val pluginVersion: String
-        get() {
-            val ideaPluginDescriptor: IdeaPluginDescriptor? =
-                PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
+    val pluginVersion: String by lazy {
+        val ideaPluginDescriptor: IdeaPluginDescriptor? =
+            PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
 
-            return ideaPluginDescriptor?.version ?: UNKNOWN
-        }
+        ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
+    }
 
-    val platformPrefix: String = PlatformUtils.getPlatformPrefix()
+    val platformPrefix: String by lazy { PlatformUtils.getPlatformPrefix() }
 }

--- a/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/PluginInfo.kt
@@ -21,7 +21,7 @@ import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 
 const val CONTAINER_TOOLS_PLUGIN_ID = "com.google.container.tools"
-const val UNKNOWN_VERSION = "N/A"
+const val UNKNOWN = "N/A"
 
 /** Utilities to get common plugin information such as its version. */
 object PluginInfo {
@@ -32,6 +32,6 @@ object PluginInfo {
             val ideaPluginDescriptor: IdeaPluginDescriptor? =
                 PluginManager.getPlugin(PluginId.getId(CONTAINER_TOOLS_PLUGIN_ID))
 
-            return ideaPluginDescriptor?.version ?: UNKNOWN_VERSION
+            return ideaPluginDescriptor?.version ?: UNKNOWN
         }
 }

--- a/core/src/main/resources/META-INF/core.xml
+++ b/core/src/main/resources/META-INF/core.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright 2018 Google Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- Declares core/utility IDE extensions and components for Container Tools -->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="com.google.container.tools.core.PluginInfo"/>
+    </extensions>
+</idea-plugin>

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+include 'core'
 include 'skaffold'
 include 'skaffold-editing'
 include 'common-test-lib'

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -91,6 +91,7 @@ abstract class SkaffoldExecutorService {
  *           configuration file. If not provided, default `skaffold.yaml` used.
  * @property workingDirectory Optional, working directory where Skaffold needs to be launched.
  *           This is usually set to project working directory.
+ * @property skaffoldLabels Kubernetes style labels to apply for Skaffold deployment.
  */
 data class SkaffoldExecutorSettings(
     val executionMode: ExecutionMode,

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -57,7 +57,7 @@ abstract class SkaffoldExecutorService {
                 add(it)
             }
             settings.skaffoldLabels?.let {
-                it.getLabels()
+                it.labels
                     .forEach { label ->
                         add("--label")
                         add("${label.key}=${label.value}")
@@ -91,7 +91,7 @@ abstract class SkaffoldExecutorService {
  *           configuration file. If not provided, default `skaffold.yaml` used.
  * @property workingDirectory Optional, working directory where Skaffold needs to be launched.
  *           This is usually set to project working directory.
- * @property skaffoldLabels Kubernetes style labels to apply for Skaffold deployment.
+ * @property skaffoldLabels Kubernetes style labels to pass to Skaffold execution.
  */
 data class SkaffoldExecutorSettings(
     val executionMode: ExecutionMode,

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -56,6 +56,13 @@ abstract class SkaffoldExecutorService {
                 add("--filename")
                 add(it)
             }
+            settings.skaffoldLabels?.let {
+                it.getLabels()
+                    .forEach { label ->
+                        add("--label")
+                        add("${label.key}=${label.value}")
+                    }
+            }
         }
 
         return SkaffoldProcess(
@@ -88,7 +95,8 @@ abstract class SkaffoldExecutorService {
 data class SkaffoldExecutorSettings(
     val executionMode: ExecutionMode,
     val skaffoldConfigurationFilePath: String? = null,
-    var workingDirectory: File? = null
+    val workingDirectory: File? = null,
+    val skaffoldLabels: SkaffoldLabels? = null
 ) {
 
     /** Execution mode for Skaffold, single run, continuous development, etc. */

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold
+
+class SkaffoldLabels {
+}

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -31,12 +31,12 @@ const val PLUGIN_VERSION_LABEL = "ijPluginVersion"
 class SkaffoldLabels {
     companion object {
         /**
-         * Creates default set of labels for all Skaffold-based deployments. Includes IDE type and
+         * Default set of labels for all Skaffold-based deployments. Includes IDE type and
          * version, plugin version.
          */
         val defaultLabels: SkaffoldLabels by lazy {
             SkaffoldLabels().apply {
-                this.labels[IDE_LABEL] = PluginInfo.getPlatformPrefix()
+                this.labels[IDE_LABEL] = PluginInfo.platformPrefix
                 this.labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
                 this.labels[PLUGIN_VERSION_LABEL] = PluginInfo.pluginVersion
             }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -16,5 +16,34 @@
 
 package com.google.container.tools.skaffold
 
+import com.google.container.tools.getPluginVersion
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.util.PlatformUtils
+import java.util.Collections
+
+const val IDE_LABEL = "ide"
+const val IDE_VERSION_LABEL = "ideVersion"
+const val PLUGIN_VERSION_LABEL = "ijPluginVersion"
+
 class SkaffoldLabels {
+    companion object {
+        fun getDefaultLabels(): SkaffoldLabels {
+            val defaultLabels = SkaffoldLabels()
+            with(defaultLabels) {
+                addLabel(IDE_LABEL, PlatformUtils.getPlatformPrefix())
+                addLabel(IDE_VERSION_LABEL, ApplicationInfo.getInstance().getStrictVersion())
+                addLabel(PLUGIN_VERSION_LABEL, getPluginVersion())
+            }
+
+            return defaultLabels
+        }
+    }
+
+    private val labels: MutableMap<String, String> = mutableMapOf()
+
+    fun addLabel(name: String, value: String) {
+        labels.put(name, value)
+    }
+
+    fun getLabels() = Collections.unmodifiableMap(labels)
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -16,11 +16,10 @@
 
 package com.google.container.tools.skaffold
 
-import com.google.container.tools.PluginInfo
+import com.google.container.tools.core.PluginInfo
 import com.google.container.tools.skaffold.SkaffoldLabels.Companion.getDefaultLabels
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.util.PlatformUtils
-import java.util.Collections
 
 const val IDE_LABEL = "ide"
 const val IDE_VERSION_LABEL = "ideVersion"
@@ -40,20 +39,14 @@ class SkaffoldLabels {
         fun getDefaultLabels(): SkaffoldLabels {
             val defaultLabels = SkaffoldLabels()
             with(defaultLabels) {
-                addLabel(IDE_LABEL, PlatformUtils.getPlatformPrefix())
-                addLabel(IDE_VERSION_LABEL, ApplicationInfo.getInstance().getStrictVersion())
-                addLabel(PLUGIN_VERSION_LABEL, PluginInfo.getPluginVersion())
+                labels[IDE_LABEL] = PlatformUtils.getPlatformPrefix()
+                labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
+                labels[PLUGIN_VERSION_LABEL] = PluginInfo.pluginVersion
             }
 
             return defaultLabels
         }
     }
 
-    private val labels: MutableMap<String, String> = mutableMapOf()
-
-    fun addLabel(name: String, value: String) {
-        labels.put(name, value)
-    }
-
-    fun getLabels() = Collections.unmodifiableMap(labels)
+    val labels: MutableMap<String, String> = mutableMapOf()
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -16,7 +16,7 @@
 
 package com.google.container.tools.skaffold
 
-import com.google.container.tools.getPluginVersion
+import com.google.container.tools.PluginInfo
 import com.google.container.tools.skaffold.SkaffoldLabels.Companion.getDefaultLabels
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.util.PlatformUtils
@@ -28,8 +28,8 @@ const val PLUGIN_VERSION_LABEL = "ijPluginVersion"
 
 /**
  * Maintains list of Kubernetes labels - string based key-value pairs used by Skaffold to apply
- * to deployments. [getDefaultLabels] function supplies default set of labels used for every
- * deployment.
+ * to all deployments. [getDefaultLabels] function supplies default set of labels used for all
+ * deployments.
  */
 class SkaffoldLabels {
     companion object {
@@ -42,7 +42,7 @@ class SkaffoldLabels {
             with(defaultLabels) {
                 addLabel(IDE_LABEL, PlatformUtils.getPlatformPrefix())
                 addLabel(IDE_VERSION_LABEL, ApplicationInfo.getInstance().getStrictVersion())
-                addLabel(PLUGIN_VERSION_LABEL, getPluginVersion())
+                addLabel(PLUGIN_VERSION_LABEL, PluginInfo.getPluginVersion())
             }
 
             return defaultLabels

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -16,6 +16,7 @@
 
 package com.google.container.tools.skaffold
 
+import com.google.common.annotations.VisibleForTesting
 import com.google.container.tools.core.PluginInfo
 import com.intellij.openapi.application.ApplicationInfo
 
@@ -35,7 +36,12 @@ class SkaffoldLabels {
          * version, plugin version.
          */
         val defaultLabels: SkaffoldLabels by lazy {
-            SkaffoldLabels().apply {
+            populateDefaultLabels()
+        }
+
+        @VisibleForTesting
+        fun populateDefaultLabels(): SkaffoldLabels {
+            return SkaffoldLabels().apply {
                 this.labels[IDE_LABEL] = PluginInfo.instance.platformPrefix
                 this.labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
                 this.labels[PLUGIN_VERSION_LABEL] = PluginInfo.instance.pluginVersion

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -36,9 +36,9 @@ class SkaffoldLabels {
          */
         val defaultLabels: SkaffoldLabels by lazy {
             SkaffoldLabels().apply {
-                this.labels[IDE_LABEL] = PluginInfo.platformPrefix
+                this.labels[IDE_LABEL] = PluginInfo.instance.platformPrefix
                 this.labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
-                this.labels[PLUGIN_VERSION_LABEL] = PluginInfo.pluginVersion
+                this.labels[PLUGIN_VERSION_LABEL] = PluginInfo.instance.pluginVersion
             }
         }
     }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -17,6 +17,7 @@
 package com.google.container.tools.skaffold
 
 import com.google.container.tools.getPluginVersion
+import com.google.container.tools.skaffold.SkaffoldLabels.Companion.getDefaultLabels
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.util.PlatformUtils
 import java.util.Collections
@@ -25,8 +26,17 @@ const val IDE_LABEL = "ide"
 const val IDE_VERSION_LABEL = "ideVersion"
 const val PLUGIN_VERSION_LABEL = "ijPluginVersion"
 
+/**
+ * Maintains list of Kubernetes labels - string based key-value pairs used by Skaffold to apply
+ * to deployments. [getDefaultLabels] function supplies default set of labels used for every
+ * deployment.
+ */
 class SkaffoldLabels {
     companion object {
+        /**
+         * Creates default set of labels for all Skaffold-based deployments. Includes IDE type and
+         * version, plugin version.
+         */
         fun getDefaultLabels(): SkaffoldLabels {
             val defaultLabels = SkaffoldLabels()
             with(defaultLabels) {

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -17,7 +17,6 @@
 package com.google.container.tools.skaffold
 
 import com.google.container.tools.core.PluginInfo
-import com.google.container.tools.skaffold.SkaffoldLabels.Companion.getDefaultLabels
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.util.PlatformUtils
 
@@ -36,15 +35,12 @@ class SkaffoldLabels {
          * Creates default set of labels for all Skaffold-based deployments. Includes IDE type and
          * version, plugin version.
          */
-        fun getDefaultLabels(): SkaffoldLabels {
-            val defaultLabels = SkaffoldLabels()
-            with(defaultLabels) {
-                labels[IDE_LABEL] = PlatformUtils.getPlatformPrefix()
-                labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
-                labels[PLUGIN_VERSION_LABEL] = PluginInfo.pluginVersion
+        val defaultLabels: SkaffoldLabels by lazy {
+            SkaffoldLabels().apply {
+                this.labels[IDE_LABEL] = PlatformUtils.getPlatformPrefix()
+                this.labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
+                this.labels[PLUGIN_VERSION_LABEL] = PluginInfo.pluginVersion
             }
-
-            return defaultLabels
         }
     }
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldLabels.kt
@@ -18,7 +18,6 @@ package com.google.container.tools.skaffold
 
 import com.google.container.tools.core.PluginInfo
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.util.PlatformUtils
 
 const val IDE_LABEL = "ide"
 const val IDE_VERSION_LABEL = "ideVersion"
@@ -37,7 +36,7 @@ class SkaffoldLabels {
          */
         val defaultLabels: SkaffoldLabels by lazy {
             SkaffoldLabels().apply {
-                this.labels[IDE_LABEL] = PlatformUtils.getPlatformPrefix()
+                this.labels[IDE_LABEL] = PluginInfo.getPlatformPrefix()
                 this.labels[IDE_VERSION_LABEL] = ApplicationInfo.getInstance().getStrictVersion()
                 this.labels[PLUGIN_VERSION_LABEL] = PluginInfo.pluginVersion
             }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -71,7 +71,7 @@ class SkaffoldCommandLineState(
                 executionMode,
                 skaffoldConfigurationFilePath,
                 workingDirectory = File(environment.project.basePath),
-                skaffoldLabels = SkaffoldLabels.getDefaultLabels()
+                skaffoldLabels = SkaffoldLabels.defaultLabels
             )
         )
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -18,6 +18,7 @@ package com.google.container.tools.skaffold.run
 
 import com.google.container.tools.skaffold.SkaffoldExecutorService
 import com.google.container.tools.skaffold.SkaffoldExecutorSettings
+import com.google.container.tools.skaffold.SkaffoldLabels
 import com.google.container.tools.skaffold.message
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.CommandLineState
@@ -69,7 +70,8 @@ class SkaffoldCommandLineState(
             SkaffoldExecutorSettings(
                 executionMode,
                 skaffoldConfigurationFilePath,
-                workingDirectory = File(environment.project.basePath)
+                workingDirectory = File(environment.project.basePath),
+                skaffoldLabels = SkaffoldLabels.getDefaultLabels()
             )
         )
 

--- a/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -20,7 +20,7 @@ skaffold.run.config.general.description=Runs Skaffold Deployment
 skaffold.run.config.single.run.name=Deploy to Kubernetes with Skaffold
 skaffold.run.config.single.run.helperText=Uses Skaffold to build and deploy your application to Kubernetes cluster exactly once.
 skaffold.run.config.dev.run.name=Continuous development on Kubernetes with Skaffold
-skaffold.run.config.dev.run.helperText=Monitors the source code, so that on any change, IDE builds and deploys your application to Kubernetes cluster.
+skaffold.run.config.dev.run.helperText=<html>Watches the dependencies of your docker image for changes, so that on any change,<br/>Skaffold builds and deploys your application to Kubernetes cluster.
 
 skaffold.configuration.label=Skaffold configuration:
 

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -108,7 +108,7 @@ class DefaultSkaffoldExecutorServiceTest {
     @Test
     fun `single skaffold label list generates correct label flag`() {
         val skaffoldLabels = SkaffoldLabels()
-        skaffoldLabels.addLabel("ide", "testIde")
+        skaffoldLabels.labels["ide"] = "testIde"
 
         val result = defaultSkaffoldExecutorService.executeSkaffold(
             SkaffoldExecutorSettings(
@@ -126,9 +126,9 @@ class DefaultSkaffoldExecutorServiceTest {
     @Test
     fun `multiple skaffold label list generates correct label flag set`() {
         val skaffoldLabels = SkaffoldLabels()
-        skaffoldLabels.addLabel("ide", "testIde")
-        skaffoldLabels.addLabel("name", "unitTest")
-        skaffoldLabels.addLabel("version", "1")
+        skaffoldLabels.labels["ide"] = "testIde"
+        skaffoldLabels.labels["name"] = "unitTest"
+        skaffoldLabels.labels["version"] = "1"
 
         val result = defaultSkaffoldExecutorService.executeSkaffold(
             SkaffoldExecutorSettings(

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -118,9 +118,10 @@ class DefaultSkaffoldExecutorServiceTest {
             )
         )
 
-        assertThat(result.commandLine).contains("--label ide=testIde")
+        assertThat(result.commandLine).isEqualTo(
+            "skaffold dev --filename test.yaml --label ide=testIde"
+        )
     }
-
 
     @Test
     fun `multiple skaffold label list generates correct label flag set`() {
@@ -137,6 +138,9 @@ class DefaultSkaffoldExecutorServiceTest {
             )
         )
 
-        assertThat(result.commandLine).contains("--label ide=testIde --label name=unitTest --label version=1")
+        assertThat(result.commandLine).isEqualTo(
+            "skaffold dev --filename test.yaml " +
+                "--label ide=testIde --label name=unitTest --label version=1"
+        )
     }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -89,4 +89,54 @@ class DefaultSkaffoldExecutorServiceTest {
 
         verify { defaultSkaffoldExecutorService.createProcess(File("/tmp"), any()) }
     }
+
+    @Test
+    fun `empty skaffold label list does not generate label flags`() {
+        val skaffoldLabels = SkaffoldLabels()
+
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml",
+                skaffoldLabels = skaffoldLabels
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold dev --filename test.yaml")
+    }
+
+    @Test
+    fun `single skaffold label list generates correct label flag`() {
+        val skaffoldLabels = SkaffoldLabels()
+        skaffoldLabels.addLabel("ide", "testIde")
+
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml",
+                skaffoldLabels = skaffoldLabels
+            )
+        )
+
+        assertThat(result.commandLine).contains("--label ide=testIde")
+    }
+
+
+    @Test
+    fun `multiple skaffold label list generates correct label flag set`() {
+        val skaffoldLabels = SkaffoldLabels()
+        skaffoldLabels.addLabel("ide", "testIde")
+        skaffoldLabels.addLabel("name", "unitTest")
+        skaffoldLabels.addLabel("version", "1")
+
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml",
+                skaffoldLabels = skaffoldLabels
+            )
+        )
+
+        assertThat(result.commandLine).contains("--label ide=testIde --label name=unitTest --label version=1")
+    }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -21,11 +21,9 @@ import com.google.container.tools.core.PluginInfo
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.util.PlatformUtils
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import org.junit.Rule
 import org.junit.Test
 
@@ -41,10 +39,9 @@ class SkaffoldLabelsTest {
     @Test
     fun `valid default skaffold labels are constructed from IDE and plugin information`() {
         // mock all sources of information that should be used for default labels
-        mockkStatic(PlatformUtils::class)
-        every { PlatformUtils.getPlatformPrefix() } answers { "TestIde" }
         every { mockApplicationInfo.strictVersion } answers { "999.9" }
         mockkObject(PluginInfo)
+        every { PluginInfo.getPlatformPrefix() } answers { "TestIde" }
         every { PluginInfo.pluginVersion } answers { "0.1" }
 
         val defaultLabels: SkaffoldLabels = SkaffoldLabels.defaultLabels

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -23,7 +23,6 @@ import com.google.container.tools.test.TestService
 import com.intellij.openapi.application.ApplicationInfo
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkObject
 import org.junit.Rule
 import org.junit.Test
 
@@ -35,14 +34,16 @@ class SkaffoldLabelsTest {
     @MockK
     @TestService
     private lateinit var mockApplicationInfo: ApplicationInfo
+    @MockK
+    @TestService
+    private lateinit var mockPluginInfo: PluginInfo
 
     @Test
     fun `valid default skaffold labels are constructed from IDE and plugin information`() {
         // mock all sources of information that should be used for default labels
         every { mockApplicationInfo.strictVersion } answers { "999.9" }
-        mockkObject(PluginInfo)
-        every { PluginInfo.platformPrefix } answers { "TestIde" }
-        every { PluginInfo.pluginVersion } answers { "0.1" }
+        every { mockPluginInfo.platformPrefix } answers { "TestIde" }
+        every { mockPluginInfo.pluginVersion } answers { "0.1" }
 
         val defaultLabels: SkaffoldLabels = SkaffoldLabels.defaultLabels
 

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -17,7 +17,7 @@
 package com.google.container.tools.skaffold
 
 import com.google.common.truth.Truth.assertThat
-import com.google.container.tools.PluginInfo
+import com.google.container.tools.core.PluginInfo
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.intellij.openapi.application.ApplicationInfo
@@ -45,12 +45,12 @@ class SkaffoldLabelsTest {
         every { PlatformUtils.getPlatformPrefix() } answers { "TestIde" }
         every { mockApplicationInfo.strictVersion } answers { "999.9" }
         mockkObject(PluginInfo)
-        every { PluginInfo.getPluginVersion() } answers { "0.1" }
+        every { PluginInfo.pluginVersion } answers { "0.1" }
 
         val defaultLabels: SkaffoldLabels = SkaffoldLabels.getDefaultLabels()
 
-        assertThat(defaultLabels.getLabels()["ide"]).isEqualTo("TestIde")
-        assertThat(defaultLabels.getLabels()["ideVersion"]).isEqualTo("999.9")
-        assertThat(defaultLabels.getLabels()["ijPluginVersion"]).isEqualTo("0.1")
+        assertThat(defaultLabels.labels["ide"]).isEqualTo("TestIde")
+        assertThat(defaultLabels.labels["ideVersion"]).isEqualTo("999.9")
+        assertThat(defaultLabels.labels["ijPluginVersion"]).isEqualTo("0.1")
     }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -41,7 +41,7 @@ class SkaffoldLabelsTest {
         // mock all sources of information that should be used for default labels
         every { mockApplicationInfo.strictVersion } answers { "999.9" }
         mockkObject(PluginInfo)
-        every { PluginInfo.getPlatformPrefix() } answers { "TestIde" }
+        every { PluginInfo.platformPrefix } answers { "TestIde" }
         every { PluginInfo.pluginVersion } answers { "0.1" }
 
         val defaultLabels: SkaffoldLabels = SkaffoldLabels.defaultLabels

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -17,12 +17,14 @@
 package com.google.container.tools.skaffold
 
 import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.PluginInfo
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.util.PlatformUtils
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import org.junit.Rule
 import org.junit.Test
@@ -37,14 +39,18 @@ class SkaffoldLabelsTest {
     private lateinit var mockApplicationInfo: ApplicationInfo
 
     @Test
-    fun `default labels are constructed from IDE and plugin information`() {
+    fun `valid default skaffold labels are constructed from IDE and plugin information`() {
+        // mock all sources of information that should be used for default labels
         mockkStatic(PlatformUtils::class)
         every { PlatformUtils.getPlatformPrefix() } answers { "TestIde" }
         every { mockApplicationInfo.strictVersion } answers { "999.9" }
+        mockkObject(PluginInfo)
+        every { PluginInfo.getPluginVersion() } answers { "0.1" }
 
-        val defaultLabels = SkaffoldLabels.getDefaultLabels()
+        val defaultLabels: SkaffoldLabels = SkaffoldLabels.getDefaultLabels()
 
         assertThat(defaultLabels.getLabels()["ide"]).isEqualTo("TestIde")
         assertThat(defaultLabels.getLabels()["ideVersion"]).isEqualTo("999.9")
+        assertThat(defaultLabels.getLabels()["ijPluginVersion"]).isEqualTo("0.1")
     }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -47,7 +47,7 @@ class SkaffoldLabelsTest {
         mockkObject(PluginInfo)
         every { PluginInfo.pluginVersion } answers { "0.1" }
 
-        val defaultLabels: SkaffoldLabels = SkaffoldLabels.getDefaultLabels()
+        val defaultLabels: SkaffoldLabels = SkaffoldLabels.defaultLabels
 
         assertThat(defaultLabels.labels["ide"]).isEqualTo("TestIde")
         assertThat(defaultLabels.labels["ideVersion"]).isEqualTo("999.9")

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold
+
+import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.test.ContainerToolsRule
+import com.google.container.tools.test.TestService
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.util.PlatformUtils
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import org.junit.Rule
+import org.junit.Test
+
+/** Unit tests for [SkaffoldLabels] class. */
+class SkaffoldLabelsTest {
+    @get:Rule
+    val containerToolsRule = ContainerToolsRule(this)
+
+    @MockK
+    @TestService
+    private lateinit var mockApplicationInfo: ApplicationInfo
+
+    @Test
+    fun `default labels are constructed from IDE and plugin information`() {
+        mockkStatic(PlatformUtils::class)
+        every { PlatformUtils.getPlatformPrefix() } answers { "TestIde" }
+        every { mockApplicationInfo.strictVersion } answers { "999.9" }
+
+        val defaultLabels = SkaffoldLabels.getDefaultLabels()
+
+        assertThat(defaultLabels.getLabels()["ide"]).isEqualTo("TestIde")
+        assertThat(defaultLabels.getLabels()["ideVersion"]).isEqualTo("999.9")
+    }
+}

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldLabelsTest.kt
@@ -45,7 +45,7 @@ class SkaffoldLabelsTest {
         every { mockPluginInfo.platformPrefix } answers { "TestIde" }
         every { mockPluginInfo.pluginVersion } answers { "0.1" }
 
-        val defaultLabels: SkaffoldLabels = SkaffoldLabels.defaultLabels
+        val defaultLabels: SkaffoldLabels = SkaffoldLabels.populateDefaultLabels()
 
         assertThat(defaultLabels.labels["ide"]).isEqualTo("TestIde")
         assertThat(defaultLabels.labels["ideVersion"]).isEqualTo("999.9")

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineStateTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineStateTest.kt
@@ -17,6 +17,7 @@
 package com.google.container.tools.skaffold.run
 
 import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.core.PluginInfo
 import com.google.container.tools.skaffold.SkaffoldExecutorService
 import com.google.container.tools.skaffold.SkaffoldExecutorSettings
 import com.google.container.tools.skaffold.SkaffoldProcess
@@ -56,6 +57,9 @@ class SkaffoldCommandLineStateTest {
     @MockK
     @TestService
     private lateinit var mockSkaffoldExecutorService: SkaffoldExecutorService
+    @MockK
+    @TestService
+    private lateinit var mockPluginInfoService: PluginInfo
 
     private val skaffoldSettingsCapturingSlot: CapturingSlot<SkaffoldExecutorSettings> = slot()
 

--- a/skaffold/src/test/resources/plugin.xml
+++ b/skaffold/src/test/resources/plugin.xml
@@ -18,5 +18,6 @@
     <id>com.google.container.tools</id>
     <name>Google Container Tools</name>
 
+    <xi:include href="/META-INF/core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
 
     <depends>com.intellij.modules.lang</depends>
 
+    <xi:include href="/META-INF/core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/skaffold.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/skaffold-editing.xml" xpointer="xpointer(/idea-plugin/*)"/>
 


### PR DESCRIPTION
Fixes #68.

When GKE cluster is used for deployment with Skaffold, labels will identify Container Tools IntelliJ plugin is used for Skaffold pipeline with additional details, such as IDE type and version.

Added `core` module for core utilities and functionality that most probably could be shared between the modules. For now it includes plugin version information there.

Labels are simple key-value pairs according to K8s specification, and passed on to Skaffold using `--label` flag.

Resulting deployment with label list, on GKE screenshot:

![skaffold-ide-labels](https://user-images.githubusercontent.com/11686100/48080887-c3cea080-e1bc-11e8-85a9-a4ddafd32295.png)
