### PR TITLE
Add a property to easily switch to alternative IDE.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ allprojects {
         version = project.properties["ideaVersion"].toString()
         intellijRepo = project.properties["intellijRepoUrl"].toString()
         updateSinceUntilBuild = false
+        project.properties["alternativeIdePath"]?.let { alternativeIdePath = it.toString() }
     }
 
     tasks.withType<KotlinCompile> {


### PR DESCRIPTION
This makes it easy to create multiple run configurations in IJ pointing to other alternative IDEs to test the plugin:

![alt-ide-path](https://user-images.githubusercontent.com/11686100/48083295-d1872480-e1c2-11e8-947d-0416a9c07787.png)
