### PR TITLE
Update APIs and fix deprecations for 2018.3 support.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@
 #
 
 ideaEdition = IC
-ideaVersion = 2018.2
+ideaVersion = 2018.3
 intellijRepoUrl = https://www.jetbrains.com/intellij-repository

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
@@ -83,7 +83,7 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
 
         notification.addAction(object :
             AnAction(message("skaffold.detect.notification.add.both.configs")) {
-            override fun actionPerformed(e: AnActionEvent?) {
+            override fun actionPerformed(e: AnActionEvent) {
                 addSkaffoldRunConfiguration(skaffoldFile.path)
                 addSkaffoldDevConfiguration(skaffoldFile.path)
                 notification.expire()

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -66,14 +66,12 @@ class SkaffoldCommandLineState(
         val skaffoldConfigurationFilePath: String? = VfsUtilCore.getRelativeLocation(
             configFile, projectBaseDir
         )
-
-        val workingDirectory: File? = File(projectBaseDir.path)
-
+        
         val skaffoldProcess = SkaffoldExecutorService.instance.executeSkaffold(
             SkaffoldExecutorSettings(
                 executionMode,
                 skaffoldConfigurationFilePath,
-                workingDirectory = workingDirectory,
+                workingDirectory = File(projectBaseDir.path),
                 skaffoldLabels = SkaffoldLabels.defaultLabels
             )
         )

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -67,8 +67,7 @@ class SkaffoldCommandLineState(
             configFile, projectBaseDir
         )
 
-        val workingDirectory: File? = environment.project.guessProjectDir()
-            ?.let { File(environment.project.guessProjectDir()!!.path) }
+        val workingDirectory: File? = File(projectBaseDir.path)
 
         val skaffoldProcess = SkaffoldExecutorService.instance.executeSkaffold(
             SkaffoldExecutorSettings(

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -66,7 +66,7 @@ class SkaffoldCommandLineState(
         val skaffoldConfigurationFilePath: String? = VfsUtilCore.getRelativeLocation(
             configFile, projectBaseDir
         )
-        
+
         val skaffoldProcess = SkaffoldExecutorService.instance.executeSkaffold(
             SkaffoldExecutorSettings(
                 executionMode,

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -26,6 +26,7 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
@@ -47,7 +48,7 @@ class SkaffoldCommandLineState(
     public override fun startProcess(): ProcessHandler {
         val runConfiguration: RunConfiguration? =
             environment.runnerAndConfigurationSettings?.configuration
-        val projectBaseDir: VirtualFile? = environment.project.baseDir
+        val projectBaseDir: VirtualFile? = environment.project.guessProjectDir()
         // ensure the configuration is valid for execution - settings are of supported type,
         // project is valid and Skaffold file is present.
         if (runConfiguration == null || runConfiguration !is AbstractSkaffoldRunConfiguration ||
@@ -66,11 +67,14 @@ class SkaffoldCommandLineState(
             configFile, projectBaseDir
         )
 
+        val workingDirectory: File? = environment.project.guessProjectDir()
+            ?.let { File(environment.project.guessProjectDir()!!.path) }
+
         val skaffoldProcess = SkaffoldExecutorService.instance.executeSkaffold(
             SkaffoldExecutorSettings(
                 executionMode,
                 skaffoldConfigurationFilePath,
-                workingDirectory = File(environment.project.basePath),
+                workingDirectory = workingDirectory,
                 skaffoldLabels = SkaffoldLabels.defaultLabels
             )
         )

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldFilesComboBox.kt
@@ -18,6 +18,7 @@ package com.google.container.tools.skaffold.run
 
 import com.google.container.tools.skaffold.SkaffoldFileService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import java.awt.Component
@@ -39,7 +40,7 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
      * in this project. First file is selected by default.
      */
     fun setProject(project: Project) {
-        setRenderer(VirtualFileRenderer(project.baseDir))
+        setRenderer(VirtualFileRenderer(project.guessProjectDir()))
         skaffoldFilesMutableModel =
             DefaultComboBoxModel<VirtualFile>(
                 SkaffoldFileService.instance.findSkaffoldFiles(project).toTypedArray()
@@ -73,7 +74,7 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
 }
 
 /** Renders name of the Skaffold file relative to the base dir of the current IDE project. */
-private class VirtualFileRenderer(val projectBaseDir: VirtualFile) : DefaultListCellRenderer() {
+private class VirtualFileRenderer(val projectBaseDir: VirtualFile?) : DefaultListCellRenderer() {
     override fun getListCellRendererComponent(
         list: JList<*>?,
         value: Any?,
@@ -83,7 +84,7 @@ private class VirtualFileRenderer(val projectBaseDir: VirtualFile) : DefaultList
     ): Component {
         val renderer =
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
-        if (value is VirtualFile && renderer is JLabel) {
+        if (value is VirtualFile && renderer is JLabel && projectBaseDir != null) {
             renderer.text = VfsUtilCore.getRelativeLocation(value, projectBaseDir)
         }
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -72,7 +72,7 @@ abstract class AbstractSkaffoldRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : RunConfigurationBase(project, factory, name) {
+) : RunConfigurationBase<Element>(project, factory, name) {
 
     /**
      * Persisted Skaffold config file absolute path for Skaffold run configurations.

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineStateTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineStateTest.kt
@@ -29,6 +29,7 @@ import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.SearchScopeProvider
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.util.ThrowableRunnable
 import io.mockk.CapturingSlot
 import io.mockk.every
@@ -36,6 +37,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
+import org.jdom.Element
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -88,7 +90,7 @@ class SkaffoldCommandLineStateTest {
 
     @Test
     fun `unsupported run configuration type throws execution exception`() {
-        val invalidSkaffoldRunConfiguration = mockk<RunConfigurationBase>()
+        val invalidSkaffoldRunConfiguration = mockk<RunConfigurationBase<Element>>()
         every { mockRunnerSettings.configuration } answers { invalidSkaffoldRunConfiguration }
 
         skaffoldCommandLineState = SkaffoldCommandLineState(
@@ -100,7 +102,8 @@ class SkaffoldCommandLineStateTest {
             ExecutionException::class,
             ThrowableRunnable { skaffoldCommandLineState.startProcess() })
         assertThat(exception.message).isEqualTo(
-            "Your Skaffold run configuration is corrupted. Please re-create it to fix.")
+            "Your Skaffold run configuration is corrupted. Please re-create it to fix."
+        )
     }
 
     @Test
@@ -120,7 +123,8 @@ class SkaffoldCommandLineStateTest {
 
     @Test
     fun `given valid settings skaffold process is executed from the project directory`() {
-        val projectBaseDir = containerToolsRule.ideaProjectTestFixture.project.baseDir.path
+        val projectBaseDir: String =
+            containerToolsRule.ideaProjectTestFixture.project.guessProjectDir()!!.path
         every { mockDevConfiguration.skaffoldConfigurationFilePath } answers {
             projectBaseDir + "/skaffold.yaml"
         }


### PR DESCRIPTION
Fixes #80.

A number of incompatible changes have been made in 2018.3, in particular with nullability of actions, generics for RunConfigBase and deprecation of project base directory property. This all has been addressed for plugin to compile and work on 2018.3