### PR TITLE
Upgrade to Kotlin 1.3 to be in line with 2018.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("org.jetbrains.intellij") version "0.3.7"
     id("com.diffplug.gradle.spotless") version "3.14.0"
 
-    kotlin("jvm") version "1.2.61"
+    kotlin("jvm") version "1.3.11"
 }
 
 allprojects {
@@ -50,7 +50,10 @@ allprojects {
         testCompile("com.google.truth:truth:+") {
             exclude(group = "com.google.guava", module = "guava")
         }
-        testCompile("io.mockk:mockk:+")
+        testCompile("io.mockk:mockk:+") {
+            // this ensures kotlin plugin/version takes precedence, mockk updates less often
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-reflect")
+        }
     }
 
     spotless {

--- a/common-test-lib/build.gradle.kts
+++ b/common-test-lib/build.gradle.kts
@@ -16,5 +16,8 @@
 
 dependencies {
     // required for container tools rule not in the test code.
-    compile("io.mockk:mockk:+")
+    compile("io.mockk:mockk:+") {
+        // this ensures kotlin plugin/version takes precedence, mockk updates less often
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-reflect")
+    }
 }


### PR DESCRIPTION
Follow up for #80.

2018.3 is Kotlin 1.3, safe to use for our code, no obsolete or deprecated features used, and use Gradle exclude to make sure kotlin plugin version takes precedence over `mockk` dependencies.