### PR TITLE
Adds tail logs support for single deployment mode

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -64,8 +64,8 @@ abstract class SkaffoldExecutorService {
                     }
             }
 
-            settings.tailLogsAfterDeploy?.let {
-                if (it == true) add("--tail")
+            settings.tailLogsAfterDeploy?.let { tailLogs ->
+                if (tailLogs) add("--tail")
             }
         }
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -63,6 +63,10 @@ abstract class SkaffoldExecutorService {
                         add("${label.key}=${label.value}")
                     }
             }
+
+            settings.tailLogsAfterDeploy?.let {
+                if (it == true) add("--tail")
+            }
         }
 
         return SkaffoldProcess(
@@ -97,7 +101,8 @@ data class SkaffoldExecutorSettings(
     val executionMode: ExecutionMode,
     val skaffoldConfigurationFilePath: String? = null,
     val workingDirectory: File? = null,
-    val skaffoldLabels: SkaffoldLabels? = null
+    val skaffoldLabels: SkaffoldLabels? = null,
+    val tailLogsAfterDeploy: Boolean? = null
 ) {
 
     /** Execution mode for Skaffold, single run, continuous development, etc. */

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -47,9 +47,9 @@ open class BaseSkaffoldSettingsEditor<C : AbstractSkaffoldRunConfiguration>(
     @VisibleForTesting
     val skaffoldFilesComboBox = SkaffoldFilesComboBox()
 
-    lateinit var basePanel: JPanel
+    protected lateinit var basePanel: JPanel
 
-    val extensionComponents: MutableMap<String, JComponent> = mutableMapOf()
+    private val extensionComponents: MutableMap<String, JComponent> = mutableMapOf()
 
     /**
      * Registers additional custom components for Skaffold configuration UI.

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -38,11 +38,11 @@ import javax.swing.JPanel
  * @param editorTitle title for the settings editor
  * @param helperText additional helper text for the settings editor
  */
-open class BaseSkaffoldSettingsEditor(
+open class BaseSkaffoldSettingsEditor<C : AbstractSkaffoldRunConfiguration>(
     val editorTitle: String,
     val helperText: String = ""
 ) :
-    SettingsEditor<AbstractSkaffoldRunConfiguration>() {
+    SettingsEditor<C>() {
 
     @VisibleForTesting
     val skaffoldFilesComboBox = SkaffoldFilesComboBox()
@@ -77,7 +77,7 @@ open class BaseSkaffoldSettingsEditor(
         return basePanel
     }
 
-    override fun applyEditorTo(runConfig: AbstractSkaffoldRunConfiguration) {
+    override fun applyEditorTo(runConfig: C) {
         val selectedSkaffoldFile: VirtualFile =
             skaffoldFilesComboBox.getItemAt(skaffoldFilesComboBox.selectedIndex)
                 ?: throw ConfigurationException(message("skaffold.no.file.selected.error"))
@@ -90,7 +90,7 @@ open class BaseSkaffoldSettingsEditor(
         runConfig.skaffoldConfigurationFilePath = selectedSkaffoldFile.path
     }
 
-    override fun resetEditorFrom(runConfig: AbstractSkaffoldRunConfiguration) {
+    override fun resetEditorFrom(runConfig: C) {
         skaffoldFilesComboBox.setProject(runConfig.project)
         runConfig.skaffoldConfigurationFilePath?.let {
             LocalFileSystem.getInstance().findFileByPath(it)

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -37,12 +37,13 @@ import javax.swing.JPanel
  *
  * @param editorTitle title for the settings editor
  * @param helperText additional helper text for the settings editor
+ * @param T type of the [AbstractSkaffoldRunConfiguration] this editor works with, i.e. run or dev.
  */
-open class BaseSkaffoldSettingsEditor<C : AbstractSkaffoldRunConfiguration>(
+open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
     val editorTitle: String,
     val helperText: String = ""
 ) :
-    SettingsEditor<C>() {
+    SettingsEditor<T>() {
 
     @VisibleForTesting
     val skaffoldFilesComboBox = SkaffoldFilesComboBox()
@@ -77,7 +78,7 @@ open class BaseSkaffoldSettingsEditor<C : AbstractSkaffoldRunConfiguration>(
         return basePanel
     }
 
-    override fun applyEditorTo(runConfig: C) {
+    override fun applyEditorTo(runConfig: T) {
         val selectedSkaffoldFile: VirtualFile =
             skaffoldFilesComboBox.getItemAt(skaffoldFilesComboBox.selectedIndex)
                 ?: throw ConfigurationException(message("skaffold.no.file.selected.error"))
@@ -90,7 +91,7 @@ open class BaseSkaffoldSettingsEditor<C : AbstractSkaffoldRunConfiguration>(
         runConfig.skaffoldConfigurationFilePath = selectedSkaffoldFile.path
     }
 
-    override fun resetEditorFrom(runConfig: C) {
+    override fun resetEditorFrom(runConfig: T) {
         skaffoldFilesComboBox.setProject(runConfig.project)
         runConfig.skaffoldConfigurationFilePath?.let {
             LocalFileSystem.getInstance().findFileByPath(it)

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditor.kt
@@ -28,6 +28,7 @@ import com.intellij.ui.layout.panel
 import com.intellij.util.ui.UIUtil
 import java.awt.Insets
 import javax.swing.JComponent
+import javax.swing.JPanel
 
 /**
  * Base settings editor for both Skaffold single run and continunous run configurations. Includes
@@ -37,21 +38,40 @@ import javax.swing.JComponent
  * @param editorTitle title for the settings editor
  * @param helperText additional helper text for the settings editor
  */
-open class BaseSkaffoldSettingsEditor(val editorTitle: String, val helperText: String = "") :
+open class BaseSkaffoldSettingsEditor(
+    val editorTitle: String,
+    val helperText: String = ""
+) :
     SettingsEditor<AbstractSkaffoldRunConfiguration>() {
 
     @VisibleForTesting
     val skaffoldFilesComboBox = SkaffoldFilesComboBox()
 
-    val basePanel = panel {
-        row {
-            label(helperText, 0, UIUtil.ComponentStyle.SMALL)
-        }
+    lateinit var basePanel: JPanel
 
-        row(message("skaffold.configuration.label")) { skaffoldFilesComboBox(grow) }
+    val extensionComponents: MutableMap<String, JComponent> = mutableMapOf()
+
+    /**
+     * Registers additional custom components for Skaffold configuration UI.
+     * @param newExtensionComponents extension components mapped to their label text
+     */
+    protected fun addExtensionComponents(newExtensionComponents: Map<String, JComponent>) {
+        extensionComponents.putAll(newExtensionComponents)
     }
 
     override fun createEditor(): JComponent {
+        basePanel = panel {
+            row {
+                label(helperText, 0, UIUtil.ComponentStyle.SMALL)
+            }
+
+            row(message("skaffold.configuration.label")) { skaffoldFilesComboBox(grow) }
+
+            extensionComponents.forEach {
+                row(it.key) { it.value(grow) }
+            }
+        }
+
         basePanel.border = IdeaTitledBorder(editorTitle, 0, Insets(0, 0, 0, 0))
 
         return basePanel

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -67,12 +67,17 @@ class SkaffoldCommandLineState(
             configFile, projectBaseDir
         )
 
+        // custom settings for single deployment (run) mode
+        val singleRunConfiguration: SkaffoldSingleRunConfiguration? =
+            if (runConfiguration is SkaffoldSingleRunConfiguration) runConfiguration else null
+
         val skaffoldProcess = SkaffoldExecutorService.instance.executeSkaffold(
             SkaffoldExecutorSettings(
                 executionMode,
                 skaffoldConfigurationFilePath,
                 workingDirectory = File(projectBaseDir.path),
-                skaffoldLabels = SkaffoldLabels.defaultLabels
+                skaffoldLabels = SkaffoldLabels.defaultLabels,
+                tailLogsAfterDeploy = singleRunConfiguration?.tailDeploymentLogs
             )
         )
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldDevSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldDevSettingsEditor.kt
@@ -24,7 +24,7 @@ import com.google.container.tools.skaffold.message
  * the settings from the project state.
  */
 class SkaffoldDevSettingsEditor :
-    BaseSkaffoldSettingsEditor(
+    BaseSkaffoldSettingsEditor<SkaffoldDevConfiguration>(
         editorTitle = message("skaffold.run.config.dev.run.name"),
         helperText = message("skaffold.run.config.dev.run.helperText")
     )

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -39,6 +39,9 @@ class SkaffoldSingleRunConfiguration(
     name: String
 ) : AbstractSkaffoldRunConfiguration(project, factory, name) {
 
+    /** Single run tail logs option to stream logs are deployment until stopped. */
+    var tailDeploymentLogs: Boolean = false
+
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? =
         SkaffoldCommandLineState(environment, SkaffoldExecutorSettings.ExecutionMode.SINGLE_RUN)
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -39,7 +39,7 @@ class SkaffoldSingleRunConfiguration(
     name: String
 ) : AbstractSkaffoldRunConfiguration(project, factory, name) {
 
-    /** Single run tail logs option to stream logs are deployment until stopped. */
+    /** Single run tail logs option to stream logs after deployment until stopped. */
     var tailDeploymentLogs: Boolean = false
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? =

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
@@ -24,7 +24,7 @@ import javax.swing.JCheckBox
  * also saves and retrieves the settings from the project state.
  */
 class SkaffoldSingleRunSettingsEditor :
-    BaseSkaffoldSettingsEditor(
+    BaseSkaffoldSettingsEditor<SkaffoldSingleRunConfiguration>(
         editorTitle = message("skaffold.run.config.single.run.name"),
         helperText = message("skaffold.run.config.single.run.helperText")
     ) {
@@ -35,19 +35,15 @@ class SkaffoldSingleRunSettingsEditor :
         addExtensionComponents(mapOf(message("skaffold.tail.logs.label") to tailLogsCheckbox))
     }
 
-    override fun applyEditorTo(runConfig: AbstractSkaffoldRunConfiguration) {
+    override fun applyEditorTo(runConfig: SkaffoldSingleRunConfiguration) {
         super.applyEditorTo(runConfig)
 
-        if (runConfig is SkaffoldSingleRunConfiguration) {
-            runConfig.tailDeploymentLogs = tailLogsCheckbox.isSelected
-        }
+        runConfig.tailDeploymentLogs = tailLogsCheckbox.isSelected
     }
 
-    override fun resetEditorFrom(runConfig: AbstractSkaffoldRunConfiguration) {
+    override fun resetEditorFrom(runConfig: SkaffoldSingleRunConfiguration) {
         super.resetEditorFrom(runConfig)
 
-        if (runConfig is SkaffoldSingleRunConfiguration) {
-            tailLogsCheckbox.isSelected = runConfig.tailDeploymentLogs
-        }
+        tailLogsCheckbox.isSelected = runConfig.tailDeploymentLogs
     }
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
@@ -17,6 +17,7 @@
 package com.google.container.tools.skaffold.run
 
 import com.google.container.tools.skaffold.message
+import javax.swing.JCheckBox
 
 /**
  * Settings editor that provides a UI for Skaffold single mode run configuration settings,
@@ -26,4 +27,19 @@ class SkaffoldSingleRunSettingsEditor :
     BaseSkaffoldSettingsEditor(
         editorTitle = message("skaffold.run.config.single.run.name"),
         helperText = message("skaffold.run.config.single.run.helperText")
-    )
+    ) {
+
+    private val tailLogsCheckbox = JCheckBox()
+
+    init {
+        addExtensionComponents(mapOf(message("skaffold.tail.logs.label") to tailLogsCheckbox))
+    }
+
+    override fun applyEditorTo(runConfig: AbstractSkaffoldRunConfiguration) {
+        super.applyEditorTo(runConfig)
+    }
+
+    override fun resetEditorFrom(runConfig: AbstractSkaffoldRunConfiguration) {
+        super.resetEditorFrom(runConfig)
+    }
+}

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
@@ -16,6 +16,7 @@
 
 package com.google.container.tools.skaffold.run
 
+import com.google.common.annotations.VisibleForTesting
 import com.google.container.tools.skaffold.message
 import javax.swing.JCheckBox
 
@@ -29,7 +30,8 @@ class SkaffoldSingleRunSettingsEditor :
         helperText = message("skaffold.run.config.single.run.helperText")
     ) {
 
-    private val tailLogsCheckbox = JCheckBox()
+    @VisibleForTesting
+    val tailLogsCheckbox = JCheckBox()
 
     init {
         addExtensionComponents(mapOf(message("skaffold.tail.logs.label") to tailLogsCheckbox))

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditor.kt
@@ -37,9 +37,17 @@ class SkaffoldSingleRunSettingsEditor :
 
     override fun applyEditorTo(runConfig: AbstractSkaffoldRunConfiguration) {
         super.applyEditorTo(runConfig)
+
+        if (runConfig is SkaffoldSingleRunConfiguration) {
+            runConfig.tailDeploymentLogs = tailLogsCheckbox.isSelected
+        }
     }
 
     override fun resetEditorFrom(runConfig: AbstractSkaffoldRunConfiguration) {
         super.resetEditorFrom(runConfig)
+
+        if (runConfig is SkaffoldSingleRunConfiguration) {
+            tailLogsCheckbox.isSelected = runConfig.tailDeploymentLogs
+        }
     }
 }

--- a/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -23,6 +23,7 @@ skaffold.run.config.dev.run.name=Continuous development on Kubernetes with Skaff
 skaffold.run.config.dev.run.helperText=<html>Watches the dependencies of your docker image for changes, so that on any change,<br/>Skaffold builds and deploys your application to a Kubernetes cluster.
 
 skaffold.configuration.label=Skaffold configuration:
+skaffold.tail.logs.label=Tail logs after deployment:
 
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -143,4 +143,30 @@ class DefaultSkaffoldExecutorServiceTest {
                 "--label ide=testIde --label name=unitTest --label version=1"
         )
     }
+
+    @Test
+    fun `tail logs option set to true generates valid command line`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml",
+                tailLogsAfterDeploy = true
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold dev --filename test.yaml --tail")
+    }
+
+    @Test
+    fun `tail logs option set to false does not add --tail option`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "skaffold.yaml",
+                tailLogsAfterDeploy = false
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold dev --filename skaffold.yaml")
+    }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/BaseSkaffoldSettingsEditorTest.kt
@@ -48,7 +48,8 @@ class BaseSkaffoldSettingsEditorTest {
     @MockK
     private lateinit var mockSkaffoldSettings: AbstractSkaffoldRunConfiguration
 
-    private lateinit var baseSkaffoldSettingsEditor: BaseSkaffoldSettingsEditor
+    private lateinit var baseSkaffoldSettingsEditor:
+        BaseSkaffoldSettingsEditor<AbstractSkaffoldRunConfiguration>
 
     @Before
     fun setUp() {

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditorTest.kt
@@ -92,4 +92,24 @@ class SkaffoldSingleRunSettingsEditorTest {
 
         assertThat(skaffoldSingleRunConfiguration.tailDeploymentLogs).isFalse()
     }
+
+    @Test
+    @UiTest
+    fun `tail logs checkbox is unselected by default`() {
+        singleRunSettingsEditor.resetFrom(skaffoldSingleRunConfiguration)
+        singleRunSettingsEditor.skaffoldFilesComboBox.setSelectedSkaffoldFile(skaffoldFile)
+
+        assertThat(singleRunSettingsEditor.tailLogsCheckbox.isSelected).isFalse()
+    }
+
+    @Test
+    @UiTest
+    fun `tail logs option is not enabled by default settings`() {
+        singleRunSettingsEditor.resetFrom(skaffoldSingleRunConfiguration)
+        singleRunSettingsEditor.skaffoldFilesComboBox.setSelectedSkaffoldFile(skaffoldFile)
+
+        singleRunSettingsEditor.applyTo(skaffoldSingleRunConfiguration)
+
+        assertThat(skaffoldSingleRunConfiguration.tailDeploymentLogs).isFalse()
+    }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/SkaffoldSingleRunSettingsEditorTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold.run
+
+import com.google.common.truth.Truth.assertThat
+import com.google.container.tools.skaffold.SkaffoldFileService
+import com.google.container.tools.test.ContainerToolsRule
+import com.google.container.tools.test.TestService
+import com.google.container.tools.test.UiTest
+import com.intellij.mock.MockVirtualFile
+import com.intellij.testFramework.EdtTestUtil
+import com.intellij.util.ThrowableRunnable
+import io.mockk.every
+import io.mockk.impl.annotations.SpyK
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/** Unit tests for [SkaffoldSingleRunSettingsEditor] */
+class SkaffoldSingleRunSettingsEditorTest {
+    @get:Rule
+    val containerToolsRule = ContainerToolsRule(this)
+
+    @SpyK
+    @TestService
+    private var mockSkaffoldFileService: SkaffoldFileService = SkaffoldFileService()
+
+    private lateinit var skaffoldSingleRunConfiguration: SkaffoldSingleRunConfiguration
+
+    private lateinit var singleRunSettingsEditor: SkaffoldSingleRunSettingsEditor
+
+    private val skaffoldFile: MockVirtualFile
+        get() {
+            val skaffoldFile = MockVirtualFile.file("test.yaml")
+            skaffoldFile.setText("apiVersion: skaffold/v1beta1")
+            return skaffoldFile
+        }
+
+    @Before
+    fun setUp() {
+        EdtTestUtil.runInEdtAndWait(ThrowableRunnable {
+            singleRunSettingsEditor = SkaffoldSingleRunSettingsEditor()
+            // calls getComponent() to initialize UI first, IDE flow.
+            singleRunSettingsEditor.component
+        })
+
+        // default valid skaffold file for tests
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf(skaffoldFile)
+
+        // empty single run configuration
+        skaffoldSingleRunConfiguration = SkaffoldSingleRunConfiguration(
+            containerToolsRule.ideaProjectTestFixture.project,
+            SkaffoldSingleRunConfigurationFactory(SkaffoldRunConfigurationType()),
+            "test"
+        )
+    }
+
+    @Test
+    @UiTest
+    fun `checked tail logs checkbox generates valid configuration`() {
+        singleRunSettingsEditor.resetFrom(skaffoldSingleRunConfiguration)
+        singleRunSettingsEditor.skaffoldFilesComboBox.setSelectedSkaffoldFile(skaffoldFile)
+        singleRunSettingsEditor.tailLogsCheckbox.isSelected = true
+
+        singleRunSettingsEditor.applyTo(skaffoldSingleRunConfiguration)
+
+        assertThat(skaffoldSingleRunConfiguration.tailDeploymentLogs).isTrue()
+    }
+
+    @Test
+    @UiTest
+    fun `unchecked tail logs checkbox generates valid configuration`() {
+        singleRunSettingsEditor.resetFrom(skaffoldSingleRunConfiguration)
+        singleRunSettingsEditor.skaffoldFilesComboBox.setSelectedSkaffoldFile(skaffoldFile)
+        singleRunSettingsEditor.tailLogsCheckbox.isSelected = false
+
+        singleRunSettingsEditor.applyTo(skaffoldSingleRunConfiguration)
+
+        assertThat(skaffoldSingleRunConfiguration.tailDeploymentLogs).isFalse()
+    }
+}


### PR DESCRIPTION
Fixes #69.

Adds UI option to enable log tailing for single (deployment) mode:

![skaffold-tail-logs-ui](https://user-images.githubusercontent.com/11686100/49662624-5b244f00-fa1a-11e8-9983-a3606cdb3e66.png)

Once deployment (successfully) completes, logs are streamed until process is killed. Deployment itself stays working:

![skaffold-tail-console](https://user-images.githubusercontent.com/11686100/49662627-5c557c00-fa1a-11e8-9a02-cda986a18ed6.png)
