### PR TITLE
Refactor API usage for automatically adding run configurations in 2018.2

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
@@ -19,15 +19,12 @@ package com.google.container.tools.skaffold
 import com.google.common.annotations.VisibleForTesting
 import com.google.container.tools.core.PLUGIN_NOTIFICATION_DISPLAY_GROUP_ID
 import com.google.container.tools.skaffold.run.AbstractSkaffoldRunConfiguration
-import com.google.container.tools.skaffold.run.SkaffoldDevConfiguration
 import com.google.container.tools.skaffold.run.SkaffoldDevConfigurationFactory
 import com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType
-import com.google.container.tools.skaffold.run.SkaffoldSingleRunConfiguration
 import com.google.container.tools.skaffold.run.SkaffoldSingleRunConfigurationFactory
 import com.intellij.execution.RunManager
+import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.RunConfiguration
-import com.intellij.execution.impl.RunManagerImpl
-import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationDisplayType
 import com.intellij.notification.NotificationGroup
@@ -95,36 +92,51 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
 
     @VisibleForTesting
     fun addSkaffoldDevConfiguration(skaffoldFilePath: String) {
-        val skaffoldDevSettings = SkaffoldDevConfiguration(
+/*        val skaffoldDevSettings = SkaffoldDevConfiguration(
             project,
             SkaffoldDevConfigurationFactory(SkaffoldRunConfigurationType()),
             message("skaffold.run.config.dev.default.name")
         )
-        skaffoldDevSettings.skaffoldConfigurationFilePath = skaffoldFilePath
+        skaffoldDevSettings.skaffoldConfigurationFilePath = skaffoldFilePath*/
 
-        createRunConfigurationFromSettings(skaffoldDevSettings)
+        createRunConfigurationFromSettings(
+            SkaffoldDevConfigurationFactory(
+                SkaffoldRunConfigurationType()
+            ), message("skaffold.run.config.dev.default.name"), skaffoldFilePath
+        )
     }
 
     @VisibleForTesting
     fun addSkaffoldRunConfiguration(skaffoldFilePath: String) {
-        val skaffoldRunSettings = SkaffoldSingleRunConfiguration(
+/*        val skaffoldRunSettings = SkaffoldSingleRunConfiguration(
             project,
             SkaffoldSingleRunConfigurationFactory(SkaffoldRunConfigurationType()),
             message("skaffold.run.config.run.default.name")
         )
-        skaffoldRunSettings.skaffoldConfigurationFilePath = skaffoldFilePath
+        skaffoldRunSettings.skaffoldConfigurationFilePath = skaffoldFilePath*/
 
-        createRunConfigurationFromSettings(skaffoldRunSettings)
+        createRunConfigurationFromSettings(
+            SkaffoldSingleRunConfigurationFactory(
+                SkaffoldRunConfigurationType()
+            ), message("skaffold.run.config.run.default.name"), skaffoldFilePath
+        )
     }
 
     /** Creates a run configuration from the given settings and selects it in run combobox */
-    private fun createRunConfigurationFromSettings(runConfiguration: RunConfiguration) {
-        val runnerAndConfigSettings = RunnerAndConfigurationSettingsImpl(
-            RunManagerImpl.getInstanceImpl(project),
-            runConfiguration
-        )
-        getRunManager(project).addConfiguration(runnerAndConfigSettings)
-        getRunManager(project).selectedConfiguration = runnerAndConfigSettings
+    private fun createRunConfigurationFromSettings(
+        factory: ConfigurationFactory,
+        name: String,
+        skaffoldFilePath: String
+    ) {
+        val runnerAndConfigSettings = getRunManager(project).createConfiguration(name, factory)
+        if (runnerAndConfigSettings.configuration is AbstractSkaffoldRunConfiguration) {
+            (runnerAndConfigSettings.configuration as AbstractSkaffoldRunConfiguration).skaffoldConfigurationFilePath =
+                skaffoldFilePath
+            getRunManager(project).addConfiguration(runnerAndConfigSettings)
+            getRunManager(project).selectedConfiguration = runnerAndConfigSettings
+        } else {
+            println("error ${runnerAndConfigSettings.configuration}")
+        }
     }
 
     @VisibleForTesting

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
@@ -45,6 +45,9 @@ import com.intellij.openapi.vfs.VirtualFile
  * @param project IDE Project for which this component is created.
  */
 class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
+
+    private val logger = Logger.getInstance(SkaffoldConfigurationDetector::class.java)
+
     private val NOTIFICATION_GROUP = NotificationGroup(
         PLUGIN_NOTIFICATION_DISPLAY_GROUP_ID,
         NotificationDisplayType.BALLOON,
@@ -119,8 +122,7 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
 
         val factory = findConfigurationFactoryById(factoryId)
         if (factory == null) {
-            Logger.getInstance(SkaffoldConfigurationDetector::class.java)
-                .warn("Skaffold configuration factory not found, plugin install is corrupted.")
+            logger.error("Skaffold configuration factory not found, plugin install is corrupted.")
             return
         }
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurationType.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurationType.kt
@@ -56,7 +56,7 @@ class SkaffoldRunConfigurationType : ConfigurationType {
  */
 class SkaffoldSingleRunConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
     companion object {
-        val RUN_ID = "google-container-tools-skaffold-run-config-run"
+        const val RUN_ID = "google-container-tools-skaffold-run-config-run"
     }
 
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
@@ -73,7 +73,7 @@ class SkaffoldSingleRunConfigurationFactory(type: ConfigurationType) : Configura
  */
 class SkaffoldDevConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
     companion object {
-        val DEV_ID = "google-container-tools-skaffold-run-config-dev"
+        const val DEV_ID = "google-container-tools-skaffold-run-config-dev"
     }
 
     override fun createTemplateConfiguration(project: Project): RunConfiguration =

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurationType.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurationType.kt
@@ -30,7 +30,9 @@ import javax.swing.Icon
  * [ConfigurationFactory].
  */
 class SkaffoldRunConfigurationType : ConfigurationType {
-    val ID = "google-container-tools-skaffold-run-config"
+    companion object {
+        const val ID = "google-container-tools-skaffold-run-config"
+    }
 
     val skaffoldSingleRunConfigurationFactory = SkaffoldSingleRunConfigurationFactory(this)
     val skaffoldDevConfigurationFactory = SkaffoldDevConfigurationFactory(this)
@@ -53,7 +55,9 @@ class SkaffoldRunConfigurationType : ConfigurationType {
  * at [SkaffoldSingleRunConfiguration].
  */
 class SkaffoldSingleRunConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
-    val RUN_ID = "google-container-tools-skaffold-run-config-run"
+    companion object {
+        val RUN_ID = "google-container-tools-skaffold-run-config-run"
+    }
 
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
         SkaffoldSingleRunConfiguration(project, this, name)
@@ -68,7 +72,9 @@ class SkaffoldSingleRunConfigurationFactory(type: ConfigurationType) : Configura
  * See template configuration at [SkaffoldDevConfiguration].
  */
 class SkaffoldDevConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
-    val DEV_ID = "google-container-tools-skaffold-run-config-dev"
+    companion object {
+        val DEV_ID = "google-container-tools-skaffold-run-config-dev"
+    }
 
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
         SkaffoldDevConfiguration(project, this, name)

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
@@ -68,6 +68,7 @@ class SkaffoldConfigurationDetectorTest {
         every {
             skaffoldConfigurationDetector.createNotification(
                 any(),
+                any(),
                 any()
             )
         } answers { mockNotification }
@@ -124,7 +125,7 @@ class SkaffoldConfigurationDetectorTest {
         } answers { mockRunnerAndConfigurationSettings }
 
         every { mockRunnerAndConfigurationSettings.getConfiguration() } answers {
-            mockk()
+            mockSkaffoldDevConfiguration
         }
 
         skaffoldConfigurationDetector.addSkaffoldDevConfiguration(skaffoldFile.path)
@@ -147,7 +148,7 @@ class SkaffoldConfigurationDetectorTest {
         } answers { mockRunnerAndConfigurationSettings }
 
         every { mockRunnerAndConfigurationSettings.getConfiguration() } answers {
-            mockk()
+            mockSkaffoldDevConfiguration
         }
 
         skaffoldConfigurationDetector.addSkaffoldRunConfiguration(skaffoldFile.path)

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
@@ -18,17 +18,17 @@ package com.google.container.tools.skaffold
 
 import com.google.common.truth.Truth.assertThat
 import com.google.container.tools.skaffold.run.SkaffoldDevConfiguration
-import com.google.container.tools.skaffold.run.SkaffoldSingleRunConfiguration
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.intellij.execution.RunManager
 import com.intellij.execution.RunnerAndConfigurationSettings
-import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.mock.MockVirtualFile
 import com.intellij.notification.Notification
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
@@ -73,6 +73,9 @@ class SkaffoldConfigurationDetectorTest {
         } answers { mockNotification }
 
         every { skaffoldConfigurationDetector.getRunManager(any()) } answers { mockRunManager }
+        every {
+            skaffoldConfigurationDetector.findConfigurationFactoryById(any())
+        } answers { mockk() }
         every { mockRunManager.addConfiguration(capture(runManagerSettingsCapture)) } returns Unit
     }
 
@@ -110,35 +113,45 @@ class SkaffoldConfigurationDetectorTest {
     fun `add dev config action creates and adds valid skaffold dev config`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf(skaffoldFile) }
+        // capture and create requested single run configuration
+        val nameSlot = slot<String>()
+        val mockRunnerAndConfigurationSettings = mockk<RunnerAndConfigurationSettings>()
+        every {
+            mockRunManager.createConfiguration(
+                capture(nameSlot),
+                any<ConfigurationFactory>()
+            )
+        } answers { mockRunnerAndConfigurationSettings }
+
+        every { mockRunnerAndConfigurationSettings.getConfiguration() } answers {
+            mockk()
+        }
 
         skaffoldConfigurationDetector.addSkaffoldDevConfiguration(skaffoldFile.path)
 
-        val runConfiguration: RunConfiguration = runManagerSettingsCapture.captured.configuration
-
-        assertThat(runConfiguration is SkaffoldDevConfiguration).isTrue()
-        assertThat(runConfiguration.name).isEqualTo("develop on Kubernetes")
-        assertThat(
-            (runConfiguration as SkaffoldDevConfiguration).skaffoldConfigurationFilePath
-        ).isEqualTo(
-            skaffoldFile.path
-        )
+        assertThat(nameSlot.captured).isEqualTo("develop on Kubernetes")
     }
 
     @Test
     fun `add run config action creates and adds valid skaffold run config`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf(skaffoldFile) }
+        // capture and create requested single run configuration
+        val nameSlot = slot<String>()
+        val mockRunnerAndConfigurationSettings = mockk<RunnerAndConfigurationSettings>()
+        every {
+            mockRunManager.createConfiguration(
+                capture(nameSlot),
+                any<ConfigurationFactory>()
+            )
+        } answers { mockRunnerAndConfigurationSettings }
+
+        every { mockRunnerAndConfigurationSettings.getConfiguration() } answers {
+            mockk()
+        }
 
         skaffoldConfigurationDetector.addSkaffoldRunConfiguration(skaffoldFile.path)
 
-        val runConfiguration: RunConfiguration = runManagerSettingsCapture.captured.configuration
-
-        assertThat(runConfiguration is SkaffoldSingleRunConfiguration).isTrue()
-        assertThat(runConfiguration.name).isEqualTo("deploy to Kubernetes")
-        assertThat(
-            (runConfiguration as SkaffoldSingleRunConfiguration).skaffoldConfigurationFilePath
-        ).isEqualTo(
-            skaffoldFile.path
-        )
+        assertThat(nameSlot.captured).isEqualTo("deploy to Kubernetes")
     }
 }


### PR DESCRIPTION
#7 enabled automatic addition of Skaffold configurations but used new API not available on 2018.2 family of IDEs. There is a more standard way to create configurations using factory IDs and configuration type which is used now and this enabled automatic configurations on 2018.2 as well as 2018.3.