### PR TITLE
Add placeholder plugin.xml plugin description field

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,12 @@
     <id>com.google.container.tools</id>
     <name>Google Container Tools</name>
     <vendor>Google</vendor>
+    <description>
+    <![CDATA[<html>
+      <p>Google Container Tools</p>
+      <p>Under development - coming soon!</p>
+    </html>]]>
+    </description>
 
     <!-- "idea-version since-build" set to cover 2017.1 - 2018.3 -->
     <!-- Set manually because the gradle-intellij-plugin cannot span across major release versions -->


### PR DESCRIPTION
I'm testing out the release process end-to-end and this field is required for publishing. 

Adding a placeholder for now. Will be updated once we put in place our initial documentation.