### PR TITLE
Fix release script env var file cat

### DIFF
--- a/kokoro/unix/release.sh
+++ b/kokoro/unix/release.sh
@@ -31,14 +31,10 @@
 ## Release script that publishes our plugins to Github and Jetbrains plugin repository
 
 ## Export required environment variables
-ANALYTICS_ID_PATH=${KOKORO_KEYSTORE_DIR}/72743_analytics_id
-GITHUB_TOKEN_PATH=${KOKORO_KEYSTORE_DIR}/72743_paflynn_github_token
-IJ_REPO_USERNAME_PATH=${KOKORO_KEYSTORE_DIR}/72743_ij_repo_username
-IJ_REPO_PASSWORD_PATH=${KOKORO_KEYSTORE_DIR}/72743_ij_repo_password
-export ANALYTICS_ID=$(cat ANALYTICS_ID_PATH)
-export GITHUB_TOKEN=$(cat GITHUB_TOKEN_PATH)
-export IJ_REPO_USERNAME=$(cat IJ_REPO_USERNAME_PATH)
-export IJ_REPO_PASSWORD=$(cat IJ_REPO_PASSWORD_PATH)
+export ANALYTICS_ID=$(cat ${KOKORO_KEYSTORE_DIR}/72743_analytics_id)
+export GITHUB_TOKEN=$(cat ${KOKORO_KEYSTORE_DIR}/72743_paflynn_github_token)
+export IJ_REPO_USERNAME=$(cat ${KOKORO_KEYSTORE_DIR}/72743_ij_repo_username)
+export IJ_REPO_PASSWORD=$(cat ${KOKORO_KEYSTORE_DIR}/72743_ij_repo_password)
 
 cd github/google-container-tools-intellij
 


### PR DESCRIPTION
There was an error in the bash script that I found doing an end-to-end release. The file path was not correctly being extracted into a variable. This fixes it (tested).