### PR TITLE
Organize test code for run.ui package.

### DIFF
--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditorTest.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.container.tools.skaffold.run
+package com.google.container.tools.skaffold.run.ui
 
 import com.google.common.truth.Truth.assertThat
 import com.google.container.tools.skaffold.SkaffoldFileService
-import com.google.container.tools.skaffold.run.ui.BaseSkaffoldSettingsEditor
+import com.google.container.tools.skaffold.run.AbstractSkaffoldRunConfiguration
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.google.container.tools.test.UiTest

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldFilesComboBoxTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldFilesComboBoxTest.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.container.tools.skaffold.run
+package com.google.container.tools.skaffold.run.ui
 
 import com.google.common.truth.Truth.assertThat
 import com.google.container.tools.skaffold.SkaffoldFileService
-import com.google.container.tools.skaffold.run.ui.SkaffoldFilesComboBox
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.google.container.tools.test.UiTest

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldSingleRunSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldSingleRunSettingsEditorTest.kt
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.container.tools.skaffold.run
+package com.google.container.tools.skaffold.run.ui
 
 import com.google.common.truth.Truth.assertThat
 import com.google.container.tools.skaffold.SkaffoldFileService
-import com.google.container.tools.skaffold.run.ui.SkaffoldSingleRunSettingsEditor
+import com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType
+import com.google.container.tools.skaffold.run.SkaffoldSingleRunConfiguration
+import com.google.container.tools.skaffold.run.SkaffoldSingleRunConfigurationFactory
 import com.google.container.tools.test.ContainerToolsRule
 import com.google.container.tools.test.TestService
 import com.google.container.tools.test.UiTest
@@ -63,11 +65,12 @@ class SkaffoldSingleRunSettingsEditorTest {
         every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf(skaffoldFile)
 
         // empty single run configuration
-        skaffoldSingleRunConfiguration = SkaffoldSingleRunConfiguration(
-            containerToolsRule.ideaProjectTestFixture.project,
-            SkaffoldSingleRunConfigurationFactory(SkaffoldRunConfigurationType()),
-            "test"
-        )
+        skaffoldSingleRunConfiguration =
+            SkaffoldSingleRunConfiguration(
+                containerToolsRule.ideaProjectTestFixture.project,
+                SkaffoldSingleRunConfigurationFactory(SkaffoldRunConfigurationType()),
+                "test"
+            )
     }
 
     @Test


### PR DESCRIPTION
Follow up for #95.

UI code for run configurations has been moved to `run.ui` package, moves remaining test code for corresponding classes there as well.