### PR TITLE
Fix write block by using PSI data when available for proper sync

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
@@ -106,6 +106,8 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
 
     override fun resetEditorFrom(runConfig: T) {
         skaffoldFilesComboBox.setProject(runConfig.project)
+        skaffoldProfilesComboBox.project = runConfig.project
+
         runConfig.skaffoldConfigurationFilePath?.let {
             LocalFileSystem.getInstance().findFileByPath(it)
         }?.let { skaffoldFilesComboBox.setSelectedSkaffoldFile(it) }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldFilesComboBox.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiManager
 import java.awt.Component
 import javax.swing.DefaultComboBoxModel
 import javax.swing.DefaultListCellRenderer
@@ -48,16 +47,6 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
             DefaultComboBoxModel<VirtualFile>(
                 items
             )
-        items.forEach { vf: VirtualFile ->
-            val psiFile = PsiManager.getInstance(project).findFile(vf)
-            psiFile?.let {
-                println("psiFile ${it.name} ${it.fileType} ${it.children} content: ${it.text}")
-                it.children.forEach { child ->
-                    println("child node ${child.node}, text ${child.node.text}")
-                }
-                println("vFile ${vf.name} content: ${String(vf.contentsToByteArray())}")
-            }
-        }
         model = skaffoldFilesMutableModel
         if (model.size > 0) selectedIndex = 0
     }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldFilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldFilesComboBox.kt
@@ -51,7 +51,10 @@ class SkaffoldFilesComboBox : JComboBox<VirtualFile>() {
         items.forEach { vf: VirtualFile ->
             val psiFile = PsiManager.getInstance(project).findFile(vf)
             psiFile?.let {
-                println("psiFile ${it.name} content: ${it.text}")
+                println("psiFile ${it.name} ${it.fileType} ${it.children} content: ${it.text}")
+                it.children.forEach { child ->
+                    println("child node ${child.node}, text ${child.node.text}")
+                }
                 println("vFile ${vf.name} content: ${String(vf.contentsToByteArray())}")
             }
         }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldProfilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldProfilesComboBox.kt
@@ -36,7 +36,7 @@ import javax.swing.JComboBox
 class SkaffoldProfilesComboBox : JComboBox<String>() {
     private val log = Logger.getInstance(this::class.java)
 
-    internal lateinit var project: Project
+    internal var project: Project? = null
 
     @VisibleForTesting
     internal val model: DefaultComboBoxModel<String> = DefaultComboBoxModel()
@@ -72,7 +72,7 @@ class SkaffoldProfilesComboBox : JComboBox<String>() {
     fun skaffoldFileUpdated(skaffoldFile: VirtualFile?) {
         val profileSet: Set<String> = skaffoldFile?.let {
             try {
-                val skaffoldYamlConfiguration = SkaffoldYamlConfiguration(skaffoldFile)
+                val skaffoldYamlConfiguration = SkaffoldYamlConfiguration(skaffoldFile, project)
                 skaffoldYamlConfiguration.profiles.keys
             } catch (e: Exception) {
                 // malformed YAML - clear and disable profiles selection.

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldProfilesComboBox.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/SkaffoldProfilesComboBox.kt
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.google.container.tools.skaffold.SkaffoldYamlConfiguration
 import com.google.container.tools.skaffold.message
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JComboBox
@@ -34,6 +35,8 @@ import javax.swing.JComboBox
  */
 class SkaffoldProfilesComboBox : JComboBox<String>() {
     private val log = Logger.getInstance(this::class.java)
+
+    internal lateinit var project: Project
 
     @VisibleForTesting
     internal val model: DefaultComboBoxModel<String> = DefaultComboBoxModel()


### PR DESCRIPTION
Fixes #114, different approach to fix #100.

Instead of saving files which is not allowed (along with file syncs and any other cache/edit save operations) from the modal dialogs, use PSI file content that contains the latest up-to-date memory representation of the file and the latest edits.