### PR TITLE
Client side metrics for auto created Skaffold configurations.

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
@@ -18,6 +18,8 @@ package com.google.container.tools.skaffold
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.container.tools.core.PLUGIN_NOTIFICATION_DISPLAY_GROUP_ID
+import com.google.container.tools.core.analytics.UsageTrackerProvider
+import com.google.container.tools.skaffold.metrics.SKAFFOLD_AUTO_CREATE_CONFIGURATIONS
 import com.google.container.tools.skaffold.run.AbstractSkaffoldRunConfiguration
 import com.google.container.tools.skaffold.run.SkaffoldDevConfigurationFactory
 import com.google.container.tools.skaffold.run.SkaffoldRunConfigurationType
@@ -93,6 +95,13 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
             override fun actionPerformed(e: AnActionEvent) {
                 addSkaffoldRunConfiguration(skaffoldFile.path)
                 addSkaffoldDevConfiguration(skaffoldFile.path)
+
+                // single client tracking ping since we offer single menu item
+                // to create both deploy/dev configurations at once
+                UsageTrackerProvider.instance.usageTracker.trackEvent(
+                    SKAFFOLD_AUTO_CREATE_CONFIGURATIONS
+                ).ping()
+
                 notification.expire()
             }
         })

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/metrics/SkaffoldTracking.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/metrics/SkaffoldTracking.kt
@@ -22,5 +22,7 @@ const val SKAFFOLD_DEV_RUN_FAIL = "skaffold.dev.run.fail"
 const val SKAFFOLD_SINGLE_RUN_SUCCESS = "skaffold.single.run"
 const val SKAFFOLD_SINGLE_RUN_FAIL = "skaffold.single.run.fail"
 
+const val SKAFFOLD_AUTO_CREATE_CONFIGURATIONS = "skaffold.auto.create.configs"
+
 /** Generic metadata field name for any error message (or error name) information. */
 const val METADATA_ERROR_MESSAGE_KEY = "error.message"


### PR DESCRIPTION
Work towards #110.

Adds client ping when a user decides to auto-create Skaffold configurations (both deploy and develop in our case) from the notification, after Skaffold configuration has been detected.