### PR TITLE
Fix for shared panel bug for users of old GCT plugin

### DIFF
--- a/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
@@ -38,12 +38,12 @@ class UsageTrackerConfigurableProvider : ConfigurableProvider() {
          * have an ID configured for this panel. Since we only want a single instance of this panel
          * to appear for all installed Google plugins, this checks to ensure that it was not already
          * registered by the GCT plugin. Once all users migrate to newer versions of the GCT plugin,
-         * we can remove this.
+         * we can remove this. For this to work, both provider classes have to have the same name.
          */
         val canCreateConfigurable: Boolean =
             Configurable.APPLICATION_CONFIGURABLE.extensionList.filter {
                 it?.providerClass != null &&
-                    it.providerClass.endsWith("UsageTrackerConfigurableProvider")
+                    it.providerClass.endsWith(this.javaClass.simpleName)
             }.size == 1
 
         return canCreateConfigurable &&

--- a/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
@@ -42,10 +42,11 @@ class UsageTrackerConfigurableProvider : ConfigurableProvider() {
          */
         val canCreateConfigurable: Boolean =
             Configurable.APPLICATION_CONFIGURABLE.extensionList.filter {
-                it?.providerClass != null
-                    && it.providerClass.endsWith("UsageTrackerConfigurableProvider")
+                it?.providerClass != null &&
+                    it.providerClass.endsWith("UsageTrackerConfigurableProvider")
             }.size == 1
 
-        return canCreateConfigurable && UsageTrackerManagerService.instance.isUsageTrackingAvailable()
+        return canCreateConfigurable &&
+            UsageTrackerManagerService.instance.isUsageTrackingAvailable()
     }
 }

--- a/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
@@ -20,6 +20,8 @@ import com.google.container.tools.core.analytics.UsageTrackerManagerService
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ConfigurableProvider
 
+private const val USAGE_TRACKER_PROVIDER_NAME = "UsageTrackerConfigurableProvider"
+
 /**
  * Class that provides the configurable which creates the "Usage Tracking" menu item under the
  * top-level "Google" menu item.
@@ -43,7 +45,7 @@ class UsageTrackerConfigurableProvider : ConfigurableProvider() {
         val canCreateConfigurable: Boolean =
             Configurable.APPLICATION_CONFIGURABLE.extensionList.filter {
                 it?.providerClass != null &&
-                    it.providerClass.endsWith(this.javaClass.simpleName)
+                    it.providerClass.endsWith(USAGE_TRACKER_PROVIDER_NAME)
             }.size == 1
 
         return canCreateConfigurable &&

--- a/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
+++ b/core/src/main/kotlin/com/google/container/tools/core/settings/UsageTrackerConfigurableProvider.kt
@@ -32,6 +32,20 @@ class UsageTrackerConfigurableProvider : ConfigurableProvider() {
      * Only create the menu item if usage tracking is available. For example, if running in dev
      * mode with no analytics ID environment variable configured, hide the usage track menu item.
      */
-    override fun canCreateConfigurable(): Boolean =
-        UsageTrackerManagerService.instance.isUsageTrackingAvailable()
+    override fun canCreateConfigurable(): Boolean {
+        /**
+         * This check is a workaround for the fact that the older versions of the GCT plugin do not
+         * have an ID configured for this panel. Since we only want a single instance of this panel
+         * to appear for all installed Google plugins, this checks to ensure that it was not already
+         * registered by the GCT plugin. Once all users migrate to newer versions of the GCT plugin,
+         * we can remove this.
+         */
+        val canCreateConfigurable: Boolean =
+            Configurable.APPLICATION_CONFIGURABLE.extensionList.filter {
+                it?.providerClass != null
+                    && it.providerClass.endsWith("UsageTrackerConfigurableProvider")
+            }.size == 1
+
+        return canCreateConfigurable && UsageTrackerManagerService.instance.isUsageTrackingAvailable()
+    }
 }

--- a/core/src/main/resources/META-INF/core.xml
+++ b/core/src/main/resources/META-INF/core.xml
@@ -26,10 +26,17 @@
         <applicationService
                 serviceImplementation="com.google.container.tools.core.properties.PluginPropertiesFileReader"/>
 
+        <!-- Configures the menu item for the Google panel. Ensure that the ID is identical in all
+        plugins that share this panel. -->
         <applicationConfigurable groupId="google" id="google.settings"
-                             instance="com.google.container.tools.core.settings.GoogleSettingsConfigurable"/>
-        <applicationConfigurable parentId="google.settings" id="google.usagetracker.settings"
-                             provider="com.google.container.tools.core.settings.UsageTrackerConfigurableProvider"/>
+                                 instance="com.google.container.tools.core.settings.GoogleSettingsConfigurable"/>
+
+        <!-- Configures the menu item for the Usage Panel. Ensure that the ID is identical in all
+        plugins that share this panel. The load order is set to "last" so that this panel loads
+        after the panel in the GCT plugin; see UsageTrackerConfigurableProvider for more info. -->
+        <applicationConfigurable order="last" parentId="google.settings"
+                                 id="google.usagetracker.settings"
+                                 provider="com.google.container.tools.core.settings.UsageTrackerConfigurableProvider"/>
 
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
fixes https://github.com/GoogleContainerTools/google-container-tools-intellij/pull/119#issuecomment-452387513

Will prevent multiple instances of the tracking panel from showing up when users are using old versions of the GCT plugin (where the panel does not have an ID configured and therefore the platform can't handle de-duplication for us).

More explanation is in the comments on the code.