### PR TITLE
Send metrics on Skaffold add configurations using project events and message bus.

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationRunManagerListener.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationRunManagerListener.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.container.tools.skaffold
+
+import com.google.container.tools.core.analytics.UsageTrackerProvider
+import com.google.container.tools.skaffold.metrics.SKAFFOLD_DEV_CONFIGURATION_ADDED
+import com.google.container.tools.skaffold.metrics.SKAFFOLD_SINGLE_RUN_CONFIGURATION_ADDED
+import com.google.container.tools.skaffold.run.SkaffoldDevConfiguration
+import com.google.container.tools.skaffold.run.SkaffoldSingleRunConfiguration
+import com.intellij.execution.RunManagerListener
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.project.Project
+
+class SkaffoldConfigurationRunManagerListener(val project: Project) : ProjectComponent {
+    override fun projectOpened() {
+        project.messageBus.connect().subscribe(RunManagerListener.TOPIC,
+            object : RunManagerListener {
+                override fun runConfigurationAdded(settings: RunnerAndConfigurationSettings) {
+                    if (settings.configuration is SkaffoldDevConfiguration) {
+                        UsageTrackerProvider.instance.usageTracker.trackEvent(
+                            SKAFFOLD_DEV_CONFIGURATION_ADDED
+                        ).ping()
+                    }
+                    if (settings.configuration is SkaffoldSingleRunConfiguration) {
+                        UsageTrackerProvider.instance.usageTracker.trackEvent(
+                            SKAFFOLD_SINGLE_RUN_CONFIGURATION_ADDED
+                        ).ping()
+                    }
+                }
+            })
+    }
+}

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationRunManagerListener.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationRunManagerListener.kt
@@ -26,6 +26,11 @@ import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
 
+/**
+ * Project component that connects itself to project message bus when any project opens and uses
+ * [RunManagerListener] events to catch additions of new Skaffold run configurations to send
+ * client side pings.
+ */
 class SkaffoldConfigurationRunManagerListener(val project: Project) : ProjectComponent {
     override fun projectOpened() {
         project.messageBus.connect().subscribe(RunManagerListener.TOPIC,

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/metrics/SkaffoldTracking.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/metrics/SkaffoldTracking.kt
@@ -22,6 +22,9 @@ const val SKAFFOLD_DEV_RUN_FAIL = "skaffold.dev.run.fail"
 const val SKAFFOLD_SINGLE_RUN_SUCCESS = "skaffold.single.run"
 const val SKAFFOLD_SINGLE_RUN_FAIL = "skaffold.single.run.fail"
 
+const val SKAFFOLD_DEV_CONFIGURATION_ADDED = "skaffold.dev.config.added"
+const val SKAFFOLD_SINGLE_RUN_CONFIGURATION_ADDED = "skaffold.single.run.config.added"
+
 const val SKAFFOLD_AUTO_CREATE_CONFIGURATIONS = "skaffold.auto.create.configs"
 
 /** Generic metadata field name for any error message (or error name) information. */

--- a/skaffold/src/main/resources/META-INF/skaffold.xml
+++ b/skaffold/src/main/resources/META-INF/skaffold.xml
@@ -24,6 +24,11 @@
                 com.google.container.tools.skaffold.SkaffoldConfigurationDetector
             </implementation-class>
         </component>
+        <component>
+            <implementation-class>
+                com.google.container.tools.skaffold.SkaffoldConfigurationRunManagerListener
+            </implementation-class>
+        </component>
     </project-components>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Fixes #110. (the last item in this issue is hard to figure out yet and I'll file a separate issue for it out of the current milestone.)

Uses project component, project message bus and Run Manager events to catch new configurations being added for Skaffold and send appropriate client tracking events.