### PR TITLE
Shows prompt to create Skaffold configurations if any YAML file in the project becomes valid Skaffold file

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
@@ -89,7 +89,8 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
                             event.file
                         ) && !hasExistingSkaffoldConfigurations()
                     ) {
-                        // content changed to be a valid Skaffold file, no configurations, prompt
+                        // content changed to be a valid Skaffold file,
+                        // and no Skaffold configurations exist, prompt
                         showPromptForSkaffoldConfigurations(project, event.file)
                     }
                 }
@@ -198,6 +199,10 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
     fun getRunManager(project: Project): RunManager =
         RunManager.getInstance(project)
 
+    /**
+     * Adds [VirtualFileListener] to [VirtualFileManager] to track project's file system changes
+     * and detect new file and content changes.
+     */
     @VisibleForTesting
     fun addVirtualFileListener(listener: VirtualFileListener) {
         VirtualFileManager.getInstance().addVirtualFileListener(

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetector.kt
@@ -83,15 +83,23 @@ class SkaffoldConfigurationDetector(val project: Project) : ProjectComponent {
         // exist yet to show prompt for configurations once Skaffold file is created.
         addVirtualFileListener(object : VirtualFileListener {
             override fun contentsChanged(event: VirtualFileEvent) {
+                checkForSkaffoldFile(event.file)
+            }
+
+            override fun fileCreated(event: VirtualFileEvent) {
+                checkForSkaffoldFile(event.file)
+            }
+
+            private fun checkForSkaffoldFile(file: VirtualFile) {
                 DumbService.getInstance(project).runWhenSmart {
-                    if (event.file.fileType is YAMLFileType &&
+                    if (file.fileType is YAMLFileType &&
                         SkaffoldFileService.instance.isSkaffoldFile(
-                            event.file
+                            file
                         ) && !hasExistingSkaffoldConfigurations()
                     ) {
                         // content changed to be a valid Skaffold file,
                         // and no Skaffold configurations exist, prompt
-                        showPromptForSkaffoldConfigurations(project, event.file)
+                        showPromptForSkaffoldConfigurations(project, file)
                     }
                 }
             }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
@@ -124,7 +124,7 @@ class SkaffoldConfigurationDetectorTest {
 
     @Test
     @UiTest
-    fun `non-Skaffold yaml file created in the project doesnt ask to add configs`() {
+    fun `non-Skaffold yaml file modified in the project doesnt ask to add configs`() {
         val nonSkaffoldFile = MockVirtualFile.file("pod.yaml")
         every { mockSkaffoldFileService.isSkaffoldFile(nonSkaffoldFile) } returns false
         every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf() }
@@ -138,7 +138,7 @@ class SkaffoldConfigurationDetectorTest {
 
     @Test
     @UiTest
-    fun `Skaffold yaml file created in the project prompts to add run configs`() {
+    fun `Skaffold yaml file modified in the project prompts to add run configs`() {
         val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
         every { mockSkaffoldFileService.isSkaffoldFile(skaffoldFile) } returns true
         every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf() }
@@ -146,6 +146,34 @@ class SkaffoldConfigurationDetectorTest {
 
         skaffoldConfigurationDetector.projectOpened()
         fileListenerCapture.captured.contentsChanged(virtualFileEvent)
+
+        verify(exactly = 1) { skaffoldConfigurationDetector.createNotification(any(), any()) }
+    }
+
+    @Test
+    @UiTest
+    fun `non-Skaffold yaml file copied or created in the project doesnt ask to add configs`() {
+        val nonSkaffoldFile = MockVirtualFile.file("pod.yaml")
+        every { mockSkaffoldFileService.isSkaffoldFile(nonSkaffoldFile) } returns false
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf() }
+        val virtualFileEvent = VirtualFileEvent(null, nonSkaffoldFile, nonSkaffoldFile.name, null)
+
+        skaffoldConfigurationDetector.projectOpened()
+        fileListenerCapture.captured.fileCreated(virtualFileEvent)
+
+        verify(exactly = 0) { skaffoldConfigurationDetector.createNotification(any(), any()) }
+    }
+
+    @Test
+    @UiTest
+    fun `Skaffold yaml file copied or created  in the project prompts to add run configs`() {
+        val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
+        every { mockSkaffoldFileService.isSkaffoldFile(skaffoldFile) } returns true
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf() }
+        val virtualFileEvent = VirtualFileEvent(null, skaffoldFile, skaffoldFile.name, null)
+
+        skaffoldConfigurationDetector.projectOpened()
+        fileListenerCapture.captured.fileCreated(virtualFileEvent)
 
         verify(exactly = 1) { skaffoldConfigurationDetector.createNotification(any(), any()) }
     }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/SkaffoldConfigurationDetectorTest.kt
@@ -26,6 +26,8 @@ import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.mock.MockVirtualFile
 import com.intellij.notification.Notification
+import com.intellij.openapi.vfs.VirtualFileEvent
+import com.intellij.openapi.vfs.VirtualFileListener
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -60,6 +62,8 @@ class SkaffoldConfigurationDetectorTest {
     @MockK
     private lateinit var mockNotification: Notification
 
+    private val fileListenerCapture: CapturingSlot<VirtualFileListener> = slot()
+
     @Before
     fun setUp() {
         skaffoldConfigurationDetector = spyk(
@@ -73,6 +77,10 @@ class SkaffoldConfigurationDetectorTest {
                 any()
             )
         } answers { mockNotification }
+
+        every {
+            skaffoldConfigurationDetector.addVirtualFileListener(capture(fileListenerCapture))
+        } returns Unit
 
         every { skaffoldConfigurationDetector.getRunManager(any()) } answers { mockRunManager }
         every {
@@ -112,6 +120,34 @@ class SkaffoldConfigurationDetectorTest {
         skaffoldConfigurationDetector.projectOpened()
 
         verify(exactly = 0) { skaffoldConfigurationDetector.createNotification(any(), any()) }
+    }
+
+    @Test
+    @UiTest
+    fun `non-Skaffold yaml file created in the project doesnt ask to add configs`() {
+        val nonSkaffoldFile = MockVirtualFile.file("pod.yaml")
+        every { mockSkaffoldFileService.isSkaffoldFile(nonSkaffoldFile) } returns false
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf() }
+        val virtualFileEvent = VirtualFileEvent(null, nonSkaffoldFile, nonSkaffoldFile.name, null)
+
+        skaffoldConfigurationDetector.projectOpened()
+        fileListenerCapture.captured.contentsChanged(virtualFileEvent)
+
+        verify(exactly = 0) { skaffoldConfigurationDetector.createNotification(any(), any()) }
+    }
+
+    @Test
+    @UiTest
+    fun `Skaffold yaml file created in the project prompts to add run configs`() {
+        val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
+        every { mockSkaffoldFileService.isSkaffoldFile(skaffoldFile) } returns true
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } answers { listOf() }
+        val virtualFileEvent = VirtualFileEvent(null, skaffoldFile, skaffoldFile.name, null)
+
+        skaffoldConfigurationDetector.projectOpened()
+        fileListenerCapture.captured.contentsChanged(virtualFileEvent)
+
+        verify(exactly = 1) { skaffoldConfigurationDetector.createNotification(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
Fixes #94.

Uses VFS manager and listener to track YAML file content and prompt to create Skaffold configs when new valid Skaffold YAML is created. This should complete automatic Skaffold presence detection in addition to file detection when a new project is opened. 

Immediately shows prompt to create Skaffold configurations if any YAML file in the project becomes valid Skaffold file and no Skaffold configurations exists.