### PR TITLE
Change plugin id to more readable format

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
 
 <!-- Core IJ plugin manifest that contains all sub-module declarations -->
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-    <id>com.google.container.tools</id>
+    <id>google-container-tools</id>
     <name>Google Container Tools</name>
     <vendor>Google</vendor>
     <description>


### PR DESCRIPTION
This ID can be surfaced to the user. One example is when using `externalDependencies.xml` file declaring this plugin as a dependency; in this case the IDE will show a notification showing this ID suggesting to install the plugin.