### PR TITLE
UI and settings for image repository override.

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldRunConfigurations.kt
@@ -87,6 +87,9 @@ abstract class AbstractSkaffoldRunConfiguration(
 
     var skaffoldProfile: String? = null
 
+    /** Image repository to use with a Skaffold run target instead of one configured by default. */
+    var imageRepositoryOverride: String? = null
+
     override fun readExternal(element: Element) {
         super.readExternal(element)
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
@@ -24,7 +24,9 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.TitledSeparator
 import com.intellij.ui.border.IdeaTitledBorder
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.layout.panel
 import com.intellij.util.ui.UIUtil
 import java.awt.Insets
@@ -52,6 +54,8 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
     @VisibleForTesting
     val skaffoldProfilesComboBox = SkaffoldProfilesComboBox()
 
+    private val overrideImageRepoTextField = JBTextField()
+
     protected lateinit var basePanel: JPanel
 
     private val extensionComponents: MutableMap<String, JComponent> = mutableMapOf()
@@ -77,9 +81,16 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
             extensionComponents.forEach {
                 row(it.key) { it.value(grow) }
             }
+
+            row {
+                TitledSeparator(message("skaffold.image.options.subtitle"))(grow)
+            }
+            row(message("skaffold.override.image.repo")) { overrideImageRepoTextField(grow) }
         }
 
         basePanel.border = IdeaTitledBorder(editorTitle, 0, Insets(0, 0, 0, 0))
+
+        overrideImageRepoTextField.emptyText.text = "docker.io/{username} or gcr.io/{project-id}"
 
         skaffoldFilesComboBox.addActionListener {
             skaffoldProfilesComboBox.skaffoldFileUpdated(
@@ -102,6 +113,9 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
         // save properties
         runConfig.skaffoldConfigurationFilePath = selectedSkaffoldFile.path
         runConfig.skaffoldProfile = skaffoldProfilesComboBox.getSelectedProfile()
+        // do not save empty repository name, convert to null
+        runConfig.imageRepositoryOverride =
+            overrideImageRepoTextField.text.let { if (it.isEmpty()) null else it }
     }
 
     override fun resetEditorFrom(runConfig: T) {
@@ -114,6 +128,10 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
 
         runConfig.skaffoldProfile?.let {
             skaffoldProfilesComboBox.setSelectedProfile(it)
+        }
+
+        runConfig.imageRepositoryOverride?.let {
+            overrideImageRepoTextField.text = it
         }
     }
 }

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
@@ -54,7 +54,8 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
     @VisibleForTesting
     val skaffoldProfilesComboBox = SkaffoldProfilesComboBox()
 
-    private val overrideImageRepoTextField = JBTextField()
+    @VisibleForTesting
+    val overrideImageRepoTextField = JBTextField()
 
     protected lateinit var basePanel: JPanel
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
@@ -91,7 +91,8 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
 
         basePanel.border = IdeaTitledBorder(editorTitle, 0, Insets(0, 0, 0, 0))
 
-        overrideImageRepoTextField.emptyText.text = "docker.io/{username} or gcr.io/{project-id}"
+        overrideImageRepoTextField.emptyText.text = "e.g. docker.io, gcr.io"
+        overrideImageRepoTextField.toolTipText = message("skaffold.override.image.repo.tooltip")
 
         skaffoldFilesComboBox.addActionListener {
             skaffoldProfilesComboBox.skaffoldFileUpdated(

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditor.kt
@@ -91,7 +91,8 @@ open class BaseSkaffoldSettingsEditor<T : AbstractSkaffoldRunConfiguration>(
 
         basePanel.border = IdeaTitledBorder(editorTitle, 0, Insets(0, 0, 0, 0))
 
-        overrideImageRepoTextField.emptyText.text = "e.g. docker.io, gcr.io"
+        overrideImageRepoTextField.emptyText.text =
+            message("skaffold.override.image.repo.empty.prompt")
         overrideImageRepoTextField.toolTipText = message("skaffold.override.image.repo.tooltip")
 
         skaffoldFilesComboBox.addActionListener {

--- a/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -33,6 +33,8 @@ skaffold.configuration.label=Skaffold configuration:
 skaffold.profile.label=Skaffold profile:
 skaffold.default.profile.name=default
 skaffold.tail.logs.label=Tail logs after deployment:
+skaffold.image.options.subtitle=Image options:
+skaffold.override.image.repo=Override image repository:
 
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.

--- a/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -35,6 +35,7 @@ skaffold.default.profile.name=default
 skaffold.tail.logs.label=Tail logs after deployment:
 skaffold.image.options.subtitle=Image options:
 skaffold.override.image.repo=Default image repository:
+skaffold.override.image.repo.empty.prompt=e.g. docker.io, gcr.io
 skaffold.override.image.repo.tooltip=<html>The default image repository allows you to omit the repository in your Kubernetes manifests.\
   <br>For example, a default image repository of "gcr.io" and an image name in your Kubernetes config of "project/app" will yield "gcr.io/project/app".
 

--- a/skaffold/src/main/resources/messages/SkaffoldBundle.properties
+++ b/skaffold/src/main/resources/messages/SkaffoldBundle.properties
@@ -34,7 +34,9 @@ skaffold.profile.label=Skaffold profile:
 skaffold.default.profile.name=default
 skaffold.tail.logs.label=Tail logs after deployment:
 skaffold.image.options.subtitle=Image options:
-skaffold.override.image.repo=Override image repository:
+skaffold.override.image.repo=Default image repository:
+skaffold.override.image.repo.tooltip=<html>The default image repository allows you to omit the repository in your Kubernetes manifests.\
+  <br>For example, a default image repository of "gcr.io" and an image name in your Kubernetes config of "project/app" will yield "gcr.io/project/app".
 
 skaffold.no.file.selected.error=Skaffold configuration file is not selected.
 skaffold.invalid.file.error=Skaffold configuration file doesn't exist or invalid.

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditorTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/run/ui/BaseSkaffoldSettingsEditorTest.kt
@@ -187,4 +187,44 @@ class BaseSkaffoldSettingsEditorTest {
         assertThat(baseSkaffoldSettingsEditor.skaffoldProfilesComboBox.getSelectedProfile())
             .isEqualTo("gcb")
     }
+
+    @Test
+    @UiTest
+    fun `given non-empty image repo override applyTo successfully saves settings`() {
+        val skaffoldFile = MockVirtualFile.file("skaffold.yaml")
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf(skaffoldFile)
+        every { mockSkaffoldFileService.isSkaffoldFile(skaffoldFile) } returns true
+        baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
+        baseSkaffoldSettingsEditor.skaffoldFilesComboBox.setSelectedSkaffoldFile(skaffoldFile)
+
+        baseSkaffoldSettingsEditor.overrideImageRepoTextField.text = "gcr.io/test-project"
+
+        // capture settings update
+        every {
+            mockSkaffoldSettings setProperty "imageRepositoryOverride" value any<String>()
+        } propertyType String::class answers {
+            assertThat(value).isEqualTo("gcr.io/test-project")
+        }
+
+        baseSkaffoldSettingsEditor.applyTo(mockSkaffoldSettings)
+    }
+
+    @Test
+    @UiTest
+    fun `given non-empty image repo resetFrom sets repo name in repo textfield`() {
+        val skaffoldFile = MockVirtualFile.file("test.yaml")
+        every { mockSkaffoldFileService.findSkaffoldFiles(any()) } returns listOf(skaffoldFile)
+        every { mockSkaffoldFileService.isSkaffoldFile(skaffoldFile) } returns true
+        every {
+            mockSkaffoldSettings.skaffoldConfigurationFilePath
+        } answers { skaffoldFile.path }
+        every { mockSkaffoldSettings.imageRepositoryOverride } answers { "docker.io/me" }
+
+        baseSkaffoldSettingsEditor.resetFrom(mockSkaffoldSettings)
+
+        assertThat(
+            baseSkaffoldSettingsEditor.overrideImageRepoTextField.text
+        )
+            .isEqualTo("docker.io/me")
+    }
 }


### PR DESCRIPTION
Work towards #52.

See #52 and GoogleContainerTools/skaffold#1057 for more details.
This PR sets up UI and settings along with unit tests for image repository override support.
The UI:

![image-repo-ui](https://user-images.githubusercontent.com/11686100/51639889-0a1bdc00-1f30-11e9-890a-04dafacfbe64.png)
