### PR TITLE
Added CLI support and tests for default image repo option.

### DIFF
--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -78,7 +78,7 @@ abstract class SkaffoldExecutorService {
                 if (tailLogs) add("--tail")
             }
 
-            settings.imageRepoOverride?.let {
+            settings.defaultImageRepo?.let {
                 add("--default-repo")
                 add(it)
             }
@@ -138,6 +138,8 @@ abstract class SkaffoldExecutorService {
  * @property workingDirectory Optional, working directory where Skaffold needs to be launched.
  *           This is usually set to project working directory.
  * @property skaffoldLabels Kubernetes style labels to pass to Skaffold execution.
+ * @property defaultImageRepo Default image repository to use instead of repo defined in Skaffold
+ *           and Kubernetes manifests.
  */
 data class SkaffoldExecutorSettings(
     val executionMode: ExecutionMode,
@@ -146,7 +148,7 @@ data class SkaffoldExecutorSettings(
     val workingDirectory: File? = null,
     val skaffoldLabels: SkaffoldLabels? = null,
     val tailLogsAfterDeploy: Boolean? = null,
-    val imageRepoOverride: String? = null
+    val defaultImageRepo: String? = null
 ) {
 
     /** Execution mode for Skaffold, single run, continuous development, etc. */

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/SkaffoldExecutorService.kt
@@ -77,6 +77,11 @@ abstract class SkaffoldExecutorService {
             settings.tailLogsAfterDeploy?.let { tailLogs ->
                 if (tailLogs) add("--tail")
             }
+
+            settings.imageRepoOverride?.let {
+                add("--default-repo")
+                add(it)
+            }
         }
 
         try {
@@ -140,7 +145,8 @@ data class SkaffoldExecutorSettings(
     val skaffoldProfile: String? = null,
     val workingDirectory: File? = null,
     val skaffoldLabels: SkaffoldLabels? = null,
-    val tailLogsAfterDeploy: Boolean? = null
+    val tailLogsAfterDeploy: Boolean? = null,
+    val imageRepoOverride: String? = null
 ) {
 
     /** Execution mode for Skaffold, single run, continuous development, etc. */

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -78,7 +78,8 @@ class SkaffoldCommandLineState(
                 skaffoldProfile = runConfiguration.skaffoldProfile,
                 workingDirectory = File(projectBaseDir.path),
                 skaffoldLabels = SkaffoldLabels.defaultLabels,
-                tailLogsAfterDeploy = singleRunConfiguration?.tailDeploymentLogs
+                tailLogsAfterDeploy = singleRunConfiguration?.tailDeploymentLogs,
+                imageRepoOverride = runConfiguration.imageRepositoryOverride
             )
         )
 

--- a/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
+++ b/skaffold/src/main/kotlin/com/google/container/tools/skaffold/run/SkaffoldCommandLineState.kt
@@ -79,7 +79,7 @@ class SkaffoldCommandLineState(
                 workingDirectory = File(projectBaseDir.path),
                 skaffoldLabels = SkaffoldLabels.defaultLabels,
                 tailLogsAfterDeploy = singleRunConfiguration?.tailDeploymentLogs,
-                imageRepoOverride = runConfiguration.imageRepositoryOverride
+                defaultImageRepo = runConfiguration.imageRepositoryOverride
             )
         )
 

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -180,8 +180,10 @@ class DefaultSkaffoldExecutorServiceTest {
             )
         )
 
-        assertThat(result.commandLine).isEqualTo("skaffold dev --filename profiles.yaml " +
-            "--profile cloudBuild")
+        assertThat(result.commandLine).isEqualTo(
+            "skaffold dev --filename profiles.yaml " +
+                "--profile cloudBuild"
+        )
     }
 
     @Test
@@ -195,5 +197,33 @@ class DefaultSkaffoldExecutorServiceTest {
         )
 
         assertThat(result.commandLine).isEqualTo("skaffold run --filename test.yaml")
+    }
+
+    @Test
+    fun `added image repo override name generates valid command line`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "skaffold.yaml",
+                imageRepoOverride = "gcr.io/k8s-tests"
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo(
+            "skaffold dev --filename skaffold.yaml " +
+                "--default-repo gcr.io/k8s-tests"
+        )
+    }
+
+    @Test
+    fun `null image repo override name generates valid command line without repo override`() {
+        val result = defaultSkaffoldExecutorService.executeSkaffold(
+            SkaffoldExecutorSettings(
+                SkaffoldExecutorSettings.ExecutionMode.DEV,
+                skaffoldConfigurationFilePath = "test.yaml"
+            )
+        )
+
+        assertThat(result.commandLine).isEqualTo("skaffold dev --filename test.yaml")
     }
 }

--- a/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
+++ b/skaffold/src/test/kotlin/com/google/container/tools/skaffold/DefaultSkaffoldExecutorServiceTest.kt
@@ -200,12 +200,12 @@ class DefaultSkaffoldExecutorServiceTest {
     }
 
     @Test
-    fun `added image repo override name generates valid command line`() {
+    fun `added default image repo name generates valid command line`() {
         val result = defaultSkaffoldExecutorService.executeSkaffold(
             SkaffoldExecutorSettings(
                 SkaffoldExecutorSettings.ExecutionMode.DEV,
                 skaffoldConfigurationFilePath = "skaffold.yaml",
-                imageRepoOverride = "gcr.io/k8s-tests"
+                defaultImageRepo = "gcr.io/k8s-tests"
             )
         )
 
@@ -216,7 +216,7 @@ class DefaultSkaffoldExecutorServiceTest {
     }
 
     @Test
-    fun `null image repo override name generates valid command line without repo override`() {
+    fun `null default image repo name generates valid command line without repo override`() {
         val result = defaultSkaffoldExecutorService.executeSkaffold(
             SkaffoldExecutorSettings(
                 SkaffoldExecutorSettings.ExecutionMode.DEV,


### PR DESCRIPTION
Fixes #52.

Adds support to pass default image repository name to Skaffold CLI and override manifest defined image repository.

Sample configuration:

![skaffold-default-repo-set](https://user-images.githubusercontent.com/11686100/51755297-4ebc8a00-208c-11e9-8be1-daf6c733cf17.png)

Resulting CLI and substituted repository with the original image name (Skaffold functionality)
![skaffold-default-repo-cli](https://user-images.githubusercontent.com/11686100/51755326-61cf5a00-208c-11e9-89f1-59a393a4fbb2.png)
:

