### PR TITLE
Use team owned GCR repository and matching image name.

### DIFF
--- a/examples/hello-spring-boot/k8s/web.yaml
+++ b/examples/hello-spring-boot/k8s/web.yaml
@@ -25,6 +25,6 @@ spec:
     spec:
       containers:
       - name: web
-        image: gcr.io/k8s-skaffold/skaffold-jib
+        image: gcr.io/cloud-tools-for-java/hello-spring-boot
         ports:
           - containerPort: 8080

--- a/examples/hello-spring-boot/skaffold.yaml
+++ b/examples/hello-spring-boot/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v1beta3
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/k8s-skaffold/skaffold-jib
+  - image: gcr.io/cloud-tools-for-java/hello-spring-boot
     jibMaven: {}
 
 # optional profile to run the jib build on Google Cloud Build


### PR DESCRIPTION
It should make it possible to run this for all team members without additional setup and makes the image name cleaner and matching the project name too.